### PR TITLE
fix #39: Default expiry duration is broken for future years

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
                 options: {
                     mainFile: 'post-expirator.php',
                     type: 'wp-plugin',
+                    exclude: ['/vendor'],
                     updateTimestamp: false,
                     processPot: function( pot, options ) {
                         // https://github.com/cedaro/grunt-wp-i18n/blob/develop/docs/examples/remove-package-metadata.md

--- a/languages/post-expirator.pot
+++ b/languages/post-expirator.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Post Expirator package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Post Expirator 2.4.1\n"
+"Project-Id-Version: Post Expirator 2.4.2\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/PublishPress-Future\n"
-"POT-Creation-Date: 2021-05-23 13:19:49+00:00\n"
+"POT-Creation-Date: 2021-06-14 04:56:29+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -36,177 +36,177 @@ msgstr ""
 msgid "Post expires at EXPIRATIONTIME on EXPIRATIONDATE"
 msgstr ""
 
-#: post-expirator.php:40
+#: post-expirator.php:32
 msgid "Settings"
 msgstr ""
 
-#: post-expirator.php:52 post-expirator.php:113
+#: post-expirator.php:53 post-expirator.php:114
 msgid "Expires"
 msgstr ""
 
-#: post-expirator.php:127
+#: post-expirator.php:128
 msgid "Never"
 msgstr ""
 
-#: post-expirator.php:219
+#: post-expirator.php:220
 msgid ""
 "Post Expirator: Will only update expiration date if already configured on "
 "post."
 msgstr ""
 
-#: post-expirator.php:351
+#: post-expirator.php:352
 msgid "Enable Post Expiration"
 msgstr ""
 
-#: post-expirator.php:354
+#: post-expirator.php:355
 msgid "The published date/time will be used as the expiration value"
 msgstr ""
 
-#: post-expirator.php:357
+#: post-expirator.php:358
 msgid "Year"
 msgstr ""
 
-#: post-expirator.php:358
+#: post-expirator.php:359
 msgid "Month"
 msgstr ""
 
-#: post-expirator.php:359
+#: post-expirator.php:360
 msgid "Day"
 msgstr ""
 
-#: post-expirator.php:395
+#: post-expirator.php:397
 msgid "Hour"
 msgstr ""
 
-#: post-expirator.php:396
+#: post-expirator.php:398
 msgid "Minute"
 msgstr ""
 
-#: post-expirator.php:417
+#: post-expirator.php:419
 msgid "How to expire"
 msgstr ""
 
-#: post-expirator.php:428
+#: post-expirator.php:430
 msgid "Expiration Categories"
 msgstr ""
 
-#: post-expirator.php:439
+#: post-expirator.php:441
 msgid ""
 "You must assign a heirarchical taxonomy to this post type to use this "
 "feature."
 msgstr ""
 
-#: post-expirator.php:441
+#: post-expirator.php:443
 msgid ""
 "More than 1 heirachical taxonomy detected.  You must assign a default "
 "taxonomy on the settings screen."
 msgstr ""
 
-#: post-expirator.php:451
+#: post-expirator.php:453
 msgid "Taxonomy Name"
 msgstr ""
 
-#: post-expirator.php:710 post-expirator.php:721 post-expirator.php:732
-#: post-expirator.php:743
+#: post-expirator.php:726 post-expirator.php:737 post-expirator.php:748
+#: post-expirator.php:759
 msgid ""
 "%1$s (%2$s) has expired at %3$s. Post status has been successfully changed "
 "to \"%4$s\"."
 msgstr ""
 
-#: post-expirator.php:754
+#: post-expirator.php:770
 msgid ""
 "%1$s (%2$s) has expired at %3$s. Post \"%4$s\" status has been successfully "
 "set."
 msgstr ""
 
-#: post-expirator.php:765
+#: post-expirator.php:781
 msgid ""
 "%1$s (%2$s) has expired at %3$s. Post \"%4$s\" status has been successfully "
 "removed."
 msgstr ""
 
-#: post-expirator.php:778 post-expirator.php:792
+#: post-expirator.php:794 post-expirator.php:808
 msgid ""
 "%1$s (%2$s) has expired at %3$s. Post \"%4$s\" have now been set to "
 "\"%5$s\"."
 msgstr ""
 
-#: post-expirator.php:815 post-expirator.php:829
+#: post-expirator.php:831 post-expirator.php:845
 msgid ""
 "%1$s (%2$s) has expired at %3$s. The following post \"%4$s\" have now been "
 "added: \"%5$s\". The full list of categories on the post are: \"%6$s\"."
 msgstr ""
 
-#: post-expirator.php:857 post-expirator.php:878
+#: post-expirator.php:873 post-expirator.php:894
 msgid ""
 "%1$s (%2$s) has expired at %3$s. The following post \"%4$s\" have now been "
 "removed: \"%5$s\". The full list of categories on the post are: \"%6$s\"."
 msgstr ""
 
-#: post-expirator.php:897
+#: post-expirator.php:913
 msgid "Post Expiration Complete \"%s\""
 msgstr ""
 
-#: post-expirator.php:933
+#: post-expirator.php:949
 msgid "[%1$s] %2$s"
 msgstr ""
 
-#: post-expirator.php:967
+#: post-expirator.php:983
 msgid "General Settings"
 msgstr ""
 
-#: post-expirator.php:968 post-expirator.php:1091
+#: post-expirator.php:984 post-expirator.php:1107
 msgid "Defaults"
 msgstr ""
 
-#: post-expirator.php:969
+#: post-expirator.php:985
 msgid "Diagnostics"
 msgstr ""
 
-#: post-expirator.php:970
+#: post-expirator.php:986
 msgid "View Debug Logs"
 msgstr ""
 
-#: post-expirator.php:981 post-expirator.php:1000
+#: post-expirator.php:997 post-expirator.php:1016
 msgid "Post Expirator Options"
 msgstr ""
 
-#: post-expirator.php:1032 post-expirator.php:1260
+#: post-expirator.php:1048 post-expirator.php:1276
 msgid "Saved Options!"
 msgstr ""
 
-#: post-expirator.php:1079
+#: post-expirator.php:1095
 msgid ""
 "The post expirator plugin sets a custom meta value, and then optionally "
 "allows you to select if you want the post changed to a draft status or "
 "deleted when it expires."
 msgstr ""
 
-#: post-expirator.php:1082
+#: post-expirator.php:1098
 msgid "Valid [postexpirator] attributes:"
 msgstr ""
 
-#: post-expirator.php:1084
+#: post-expirator.php:1100
 msgid "type - defaults to full - valid options are full,date,time"
 msgstr ""
 
-#: post-expirator.php:1085
+#: post-expirator.php:1101
 msgid ""
 "dateformat - format set here will override the value set on the settings "
 "page"
 msgstr ""
 
-#: post-expirator.php:1086
+#: post-expirator.php:1102
 msgid ""
 "timeformat - format set here will override the value set on the settings "
 "page"
 msgstr ""
 
-#: post-expirator.php:1094
+#: post-expirator.php:1110
 msgid "Date Format:"
 msgstr ""
 
-#: post-expirator.php:1098
+#: post-expirator.php:1114
 msgid ""
 "The default format to use when displaying the expiration date within a post "
 "using the [postexpirator] shortcode or within the footer.  For information "
@@ -215,11 +215,11 @@ msgid ""
 "target=\"_blank\">PHP Date Function</a>."
 msgstr ""
 
-#: post-expirator.php:1102
+#: post-expirator.php:1118
 msgid "Time Format:"
 msgstr ""
 
-#: post-expirator.php:1106
+#: post-expirator.php:1122
 msgid ""
 "The default format to use when displaying the expiration time within a post "
 "using the [postexpirator] shortcode or within the footer.  For information "
@@ -228,325 +228,324 @@ msgid ""
 "target=\"_blank\">PHP Date Function</a>."
 msgstr ""
 
-#: post-expirator.php:1110
+#: post-expirator.php:1126
 msgid "Default Date/Time Duration:"
 msgstr ""
 
-#: post-expirator.php:1113
+#: post-expirator.php:1129
 msgid "None"
 msgstr ""
 
-#: post-expirator.php:1114
+#: post-expirator.php:1130
 msgid "Custom"
 msgstr ""
 
-#: post-expirator.php:1115
+#: post-expirator.php:1131
 msgid "Post/Page Publish Time"
 msgstr ""
 
-#: post-expirator.php:1118
+#: post-expirator.php:1134
 msgid ""
 "Set the default expiration date to be used when creating new posts and "
 "pages.  Defaults to none."
 msgstr ""
 
-#: post-expirator.php:1123
+#: post-expirator.php:1139
 msgid ""
 "Set the custom value to use for the default expiration date.  For "
-"information on formatting, see <a "
-"href=\"http://php.net/manual/en/function.strtotime.php\">PHP strtotime "
-"function</a>. For example, you could enter \"+1 month\" or \"+1 week 2 days "
-"4 hours 2 seconds\" or \"next Thursday.\""
+"information on formatting, see %1$s. For example, you could enter %2$s+1 "
+"month%3$s or %4$s+1 week 2 days 4 hours 2 seconds%5$s or %6$snext "
+"Thursday%7$s."
 msgstr ""
 
-#: post-expirator.php:1128
+#: post-expirator.php:1144
 msgid "Category Expiration"
 msgstr ""
 
-#: post-expirator.php:1131
+#: post-expirator.php:1147
 msgid "Default Expiration Category"
 msgstr ""
 
-#: post-expirator.php:1142
+#: post-expirator.php:1158
 msgid "Set's the default expiration category for the post."
 msgstr ""
 
-#: post-expirator.php:1147
+#: post-expirator.php:1163
 msgid "Expiration Email Notification"
 msgstr ""
 
-#: post-expirator.php:1148
+#: post-expirator.php:1164
 msgid ""
 "Whenever a post expires, an email can be sent to alert users of the "
 "expiration."
 msgstr ""
 
-#: post-expirator.php:1151
+#: post-expirator.php:1167
 msgid "Enable Email Notification?"
 msgstr ""
 
-#: post-expirator.php:1153 post-expirator.php:1163 post-expirator.php:1186
-#: post-expirator.php:1323
+#: post-expirator.php:1169 post-expirator.php:1179 post-expirator.php:1202
+#: post-expirator.php:1339
 msgid "Enabled"
 msgstr ""
 
-#: post-expirator.php:1155 post-expirator.php:1165 post-expirator.php:1188
-#: post-expirator.php:1325
+#: post-expirator.php:1171 post-expirator.php:1181 post-expirator.php:1204
+#: post-expirator.php:1341
 msgid "Disabled"
 msgstr ""
 
-#: post-expirator.php:1157
+#: post-expirator.php:1173
 msgid ""
 "This will enable or disable the send of email notification on post "
 "expiration."
 msgstr ""
 
-#: post-expirator.php:1161
+#: post-expirator.php:1177
 msgid "Include Blog Administrators?"
 msgstr ""
 
-#: post-expirator.php:1167
+#: post-expirator.php:1183
 msgid ""
 "This will include all users with the role of \"Administrator\" in the post "
 "expiration email."
 msgstr ""
 
-#: post-expirator.php:1171 post-expirator.php:1337
+#: post-expirator.php:1187 post-expirator.php:1353
 msgid "Who to notify:"
 msgstr ""
 
-#: post-expirator.php:1175
+#: post-expirator.php:1191
 msgid ""
 "Enter a comma seperate list of emails that you would like to be notified "
 "when the post expires.  This will be applied to ALL post types.  You can "
 "set post type specific emails on the Defaults tab."
 msgstr ""
 
-#: post-expirator.php:1180
+#: post-expirator.php:1196
 msgid "Post Footer Display"
 msgstr ""
 
-#: post-expirator.php:1181
+#: post-expirator.php:1197
 msgid ""
 "Enabling this below will display the expiration date automatically at the "
 "end of any post which is set to expire."
 msgstr ""
 
-#: post-expirator.php:1184
+#: post-expirator.php:1200
 msgid "Show in post footer?"
 msgstr ""
 
-#: post-expirator.php:1190
+#: post-expirator.php:1206
 msgid ""
 "This will enable or disable displaying the post expiration date in the post "
 "footer."
 msgstr ""
 
-#: post-expirator.php:1194
+#: post-expirator.php:1210
 msgid "Footer Contents:"
 msgstr ""
 
-#: post-expirator.php:1198
+#: post-expirator.php:1214
 msgid ""
 "Enter the text you would like to appear at the bottom of every post that "
 "will expire.  The following placeholders will be replaced with the post "
 "expiration date in the following format:"
 msgstr ""
 
-#: post-expirator.php:1207
+#: post-expirator.php:1223
 msgid "Footer Style:"
 msgstr ""
 
-#: post-expirator.php:1210
+#: post-expirator.php:1226
 msgid "This post will expire on"
 msgstr ""
 
-#: post-expirator.php:1212
+#: post-expirator.php:1228
 msgid "The inline css which will be used to style the footer text."
 msgstr ""
 
-#: post-expirator.php:1217 post-expirator.php:1351
+#: post-expirator.php:1233 post-expirator.php:1367
 msgid "Save Changes"
 msgstr ""
 
-#: post-expirator.php:1268
+#: post-expirator.php:1284
 msgid "Default Expiration Values"
 msgstr ""
 
-#: post-expirator.php:1270
+#: post-expirator.php:1286
 msgid ""
 "Use the values below to set the default actions/values to be used for each "
 "for the corresponding post types.  These values can all be overwritten when "
 "creating/editing the post/page."
 msgstr ""
 
-#: post-expirator.php:1302
+#: post-expirator.php:1318
 msgid "Active:"
 msgstr ""
 
-#: post-expirator.php:1304
+#: post-expirator.php:1320
 msgid "Active"
 msgstr ""
 
-#: post-expirator.php:1306
+#: post-expirator.php:1322
 msgid "Inactive"
 msgstr ""
 
-#: post-expirator.php:1308
+#: post-expirator.php:1324
 msgid "Select whether the post expirator meta box is active for this post type."
 msgstr ""
 
-#: post-expirator.php:1312
+#: post-expirator.php:1328
 msgid "How to expire:"
 msgstr ""
 
-#: post-expirator.php:1317
+#: post-expirator.php:1333
 msgid "Select the default expire action for the post type."
 msgstr ""
 
-#: post-expirator.php:1321
+#: post-expirator.php:1337
 msgid "Auto-Enable?"
 msgstr ""
 
-#: post-expirator.php:1327
+#: post-expirator.php:1343
 msgid "Select whether the post expirator is enabled for all new posts."
 msgstr ""
 
-#: post-expirator.php:1331
+#: post-expirator.php:1347
 msgid "Taxonomy (hierarchical):"
 msgstr ""
 
-#: post-expirator.php:1341
+#: post-expirator.php:1357
 msgid ""
 "Enter a comma seperate list of emails that you would like to be notified "
 "when the post expires."
 msgstr ""
 
-#: post-expirator.php:1369
+#: post-expirator.php:1385
 msgid "Debugging Disabled"
 msgstr ""
 
-#: post-expirator.php:1374
+#: post-expirator.php:1390
 msgid "Debugging Enabled"
 msgstr ""
 
-#: post-expirator.php:1381
+#: post-expirator.php:1397
 msgid "Debugging Table Emptied"
 msgstr ""
 
-#: post-expirator.php:1390
+#: post-expirator.php:1406
 msgid "Advanced Diagnostics"
 msgstr ""
 
-#: post-expirator.php:1393
+#: post-expirator.php:1409
 msgid "Post Expirator Debug Logging:"
 msgstr ""
 
-#: post-expirator.php:1397
+#: post-expirator.php:1413
 msgid "Status: Enabled"
 msgstr ""
 
-#: post-expirator.php:1398
+#: post-expirator.php:1414
 msgid "Disable Debugging"
 msgstr ""
 
-#: post-expirator.php:1400
+#: post-expirator.php:1416
 msgid "Status: Disabled"
 msgstr ""
 
-#: post-expirator.php:1401
+#: post-expirator.php:1417
 msgid "Enable Debugging"
 msgstr ""
 
-#: post-expirator.php:1409
+#: post-expirator.php:1425
 msgid "Purge Debug Log:"
 msgstr ""
 
-#: post-expirator.php:1411
+#: post-expirator.php:1427
 msgid "Purge Debug Log"
 msgstr ""
 
-#: post-expirator.php:1415
+#: post-expirator.php:1431
 msgid "WP-Cron Status:"
 msgstr ""
 
-#: post-expirator.php:1419
+#: post-expirator.php:1435
 msgid "DISABLED"
 msgstr ""
 
-#: post-expirator.php:1421
+#: post-expirator.php:1437
 msgid "ENABLED - OK"
 msgstr ""
 
-#: post-expirator.php:1427
+#: post-expirator.php:1443
 msgid "Current Cron Schedule:"
 msgstr ""
 
-#: post-expirator.php:1429
+#: post-expirator.php:1445
 msgid ""
 "The below table will show all currently scheduled cron events with the next "
 "run time."
 msgstr ""
 
-#: post-expirator.php:1432
+#: post-expirator.php:1448
 msgid "Date"
 msgstr ""
 
-#: post-expirator.php:1433
+#: post-expirator.php:1449
 msgid "Event"
 msgstr ""
 
-#: post-expirator.php:1434
+#: post-expirator.php:1450
 msgid "Arguments / Schedule"
 msgstr ""
 
-#: post-expirator.php:1459
+#: post-expirator.php:1475
 msgid "Single Event"
 msgstr ""
 
-#: post-expirator.php:1483
+#: post-expirator.php:1499
 msgid ""
 "Below is a dump of the debugging table, this should be useful for "
 "troubleshooting."
 msgstr ""
 
-#: post-expirator.php:1887
+#: post-expirator.php:1903
 msgid "Draft"
 msgstr ""
 
-#: post-expirator.php:1888
+#: post-expirator.php:1904
 msgid "Delete"
 msgstr ""
 
-#: post-expirator.php:1889
+#: post-expirator.php:1905
 msgid "Trash"
 msgstr ""
 
-#: post-expirator.php:1890
+#: post-expirator.php:1906
 msgid "Private"
 msgstr ""
 
-#: post-expirator.php:1891
+#: post-expirator.php:1907
 msgid "Stick"
 msgstr ""
 
-#: post-expirator.php:1892
+#: post-expirator.php:1908
 msgid "Unstick"
 msgstr ""
 
-#: post-expirator.php:1894
+#: post-expirator.php:1910
 msgid "Category: Replace"
 msgstr ""
 
-#: post-expirator.php:1895
+#: post-expirator.php:1911
 msgid "Category: Add"
 msgstr ""
 
-#: post-expirator.php:1896
+#: post-expirator.php:1912
 msgid "Category: Remove"
 msgstr ""
 
-#: post-expirator.php:1945
+#: post-expirator.php:1961
 msgid ""
 "Select the hierarchical taxonomy to be used for \"category\" based "
 "expiration."

--- a/post-expirator.php
+++ b/post-expirator.php
@@ -342,7 +342,7 @@ function postexpirator_meta_box( $post ) {
 		$disabled   = '';
 		$opts       = get_post_meta( $post->ID, '_expiration-date-options', true );
 		if ( isset( $opts['expireType'] ) ) {
-					$expireType = $opts['expireType'];
+			$expireType = $opts['expireType'];
 		}
 		$categories = isset( $opts['category'] ) ? $opts['category'] : false;
 	}
@@ -368,7 +368,8 @@ function postexpirator_meta_box( $post ) {
 		}
 
 		for ( $i = $currentyear; $i <= $currentyear + 10; $i++ ) {
-			if ( $i === $defaultyear ) {
+			// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+			if ( $i == $defaultyear ) {
 				$selected = ' selected="selected"';
 			} else {
 				$selected = '';
@@ -1135,7 +1136,7 @@ function postexpirator_menu_general() {
 					<div id="expired-custom-container" style="display: <?php echo $show; ?>;">
 					<br/><label for="expired-custom-expiration-date">Custom:</label> <input type="text" value="<?php echo $expirationdateDefaultDateCustom; ?>" name="expired-custom-expiration-date" id="expired-custom-expiration-date" />
 					<br/>
-					<?php _e( 'Set the custom value to use for the default expiration date.  For information on formatting, see <a href="http://php.net/manual/en/function.strtotime.php">PHP strtotime function</a>. For example, you could enter "+1 month" or "+1 week 2 days 4 hours 2 seconds" or "next Thursday."', 'post-expirator' ); ?>
+					<?php echo sprintf( __( 'Set the custom value to use for the default expiration date.  For information on formatting, see %1$s. For example, you could enter %2$s+1 month%3$s or %4$s+1 week 2 days 4 hours 2 seconds%5$s or %6$snext Thursday%7$s.', 'post-expirator' ), '<a href="http://php.net/manual/en/function.strtotime.php" target="_new">PHP strtotime function</a>', '<code>', '</code>', '<code>', '</code>', '<code>', '</code>' ); ?>
 					</div>
 				</td>
 			</tr>


### PR DESCRIPTION
#39 

- fixed issue with future year (introduced as part of 2.4.2)
- improved field description to avoid confusion

![image](https://user-images.githubusercontent.com/12953439/121839779-6eee5180-ccf8-11eb-92a7-c648bfafcac8.png)