### PR TITLE
fix for #24: selected was never added to the year dropdown

### DIFF
--- a/post-expirator.php
+++ b/post-expirator.php
@@ -368,7 +368,7 @@ function postexpirator_meta_box( $post ) {
 		}
 
 		for ( $i = $currentyear; $i <= $currentyear + 10; $i++ ) {
-			if ( $i === $defaultyear ) {
+			if ( $i == $defaultyear ) {
 				$selected = ' selected="selected"';
 			} else {
 				$selected = '';


### PR DESCRIPTION
This is solving [Issue 24](https://github.com/publishpress/PublishPress-Future/issues/24) because $defaultdate is no number.