### PR TITLE
Fix broken link to debug log

### DIFF
--- a/views/menu-diagnostics.php
+++ b/views/menu-diagnostics.php
@@ -19,7 +19,7 @@
                         ) . '" />'; ?>
                     <?php
                     echo '<a href="' . admin_url(
-                            'options-general.php?page=post-expirator.php&tab=viewdebug'
+                            'admin.php?page=publishpress-future&tab=viewdebug'
                         ) . '">' . __('View Debug Logs', 'post-expirator') . '</a>'; ?>
                 <?php
                 else: ?>


### PR DESCRIPTION
Just fixing a broken link to debug log

See https://wordpress.org/support/topic/debug-log-link-broken/
