### PR TITLE
Metabox consistency

### DIFF
--- a/assets/jsx/components/FutureActionPanelBlockEditor.jsx
+++ b/assets/jsx/components/FutureActionPanelBlockEditor.jsx
@@ -54,7 +54,6 @@ export const FutureActionPanelBlockEditor = (props) => {
         <PluginDocumentSettingPanel
             name={'publishpress-future-action-panel'}
             title={props.strings.panelTitle}
-            icon="calendar"
             initialOpen={props.postTypeDefaultConfig.autoEnable}
             className={'post-expirator-panel'}>
             <div id='publishpress-future-block-editor'>


### PR DESCRIPTION
This pull request removes the icon from the Future metabox in the block editor. The icon was previously set to "calendar" but is no longer needed. This change improves the visual consistency of the block editor.