### PR TITLE
Only apply the custom title for the correct page, #1037

### DIFF
--- a/src/Modules/Workflows/Controllers/WorkflowsList.php
+++ b/src/Modules/Workflows/Controllers/WorkflowsList.php
@@ -403,6 +403,10 @@ class WorkflowsList implements InitializableInterface
 
     public function fixWorkflowEditorPageTitle()
     {
+        if (!isset($_GET['page']) || 'future_workflow_editor' !== $_GET['page']) {
+            return;
+        }
+
         global $title;
 
         $title = __("Action Workflow Editor", "post-expirator");


### PR DESCRIPTION
Fix #1037 applying the custom page title only to the workflow editor page.