### PR TITLE
Update output schema in QueryPosts

### DIFF
--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/AddPostTerm.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/AddPostTerm.php
@@ -121,7 +121,7 @@ class AddPostTerm implements StepTypeInterface
                         "rule" => "validVariable",
                         "field" => "post.variable",
                         "fieldLabel" => __("Post", "post-expirator"),
-                        "dataType" => "post",
+                        "dataType" => ["post", "array:integer", "integer"],
                     ],
                 ],
             ],

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/QueryPosts.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/QueryPosts.php
@@ -106,11 +106,12 @@ class QueryPosts implements StepTypeInterface
     {
         return [
             [
-                "name" => "post",
-                "type" => "post",
-                "label" => __("Queried post", "post-expirator"),
-                "description" => __("The post that was queried.", "post-expirator"),
-            ]
+                "name" => "posts",
+                "type" => "array",
+                "itemsType" => "integer",
+                "label" => __("Array of queried post IDs", "post-expirator"),
+                "description" => __("The posts found following the criteria of the query.", "post-expirator"),
+            ],
         ];
     }
 


### PR DESCRIPTION
Update output schema in Query Posts to return an array of queried post IDs instead of a single post.