### PR TITLE
Enhance Stick and Unstick Post workflows to allow usage outside Schedule branches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED - 4.7
 
+### Changed
+
+- Stick and Unstick Post workflow steps can now be used anywhere in workflows, not just within Schedule branches (Issue #1204).
+
 ### Removed
 
 - Remove site metadata from the execution context on workflows (Issue #1332).

--- a/docs/step-validation-schema.md
+++ b/docs/step-validation-schema.md
@@ -1,0 +1,28 @@
+# Step validation schema
+
+## Requiring specific ascendent connection
+
+Add the following rules to the `getValidationSchema` method in the step definition class.
+
+```php
+public function getValidationSchema(): array
+{
+    return [
+        "connections" => [
+            "rules" => [
+                [
+                    "rule" => "hasIncomingConnection",
+                ],
+                [
+                    "rule" => "hasIncomerOfName",
+                    "name" => "advanced/core.schedule",
+                    "message" => __(
+                        "Please include a \"Schedule\" step earlier in this branch of the workflow.",
+                        "post-expirator"
+                    ),
+                ],
+            ],
+        ],
+    ];
+}
+```

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/StickPost.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/StickPost.php
@@ -92,14 +92,6 @@ class StickPost implements StepTypeInterface
                     [
                         "rule" => "hasIncomingConnection",
                     ],
-                    [
-                        "rule" => "hasIncomerOfName",
-                        "name" => "advanced/core.schedule",
-                        "message" => __(
-                            "Please include a \"Schedule\" step earlier in this branch of the workflow.",
-                            "post-expirator"
-                        ),
-                    ],
                 ],
             ],
             "settings" => [

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/UnstickPost.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/UnstickPost.php
@@ -92,14 +92,6 @@ class UnstickPost implements StepTypeInterface
                     [
                         "rule" => "hasIncomingConnection",
                     ],
-                    [
-                        "rule" => "hasIncomerOfName",
-                        "name" => "advanced/core.schedule",
-                        "message" => __(
-                            "Please include a \"Schedule\" step earlier in this branch of the workflow.",
-                            "post-expirator"
-                        ),
-                    ],
                 ],
             ],
             "settings" => [

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/StickPostRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/StickPostRunner.php
@@ -50,8 +50,20 @@ class StickPostRunner implements StepRunnerInterface
         $this->stepProcessor->executeSafelyWithErrorHandling(
             $step,
             function ($step, $postId) {
-                $postModel = call_user_func($this->expirablePostModelFactory, $postId);
-                $postModel->stick();
+                /*
+                 * Handle quick-edit saving, otherwise it will override the sticky status at the end of the save
+                 *
+                 * @see https://github.com/publishpress/PublishPress-Future/issues/1204
+                 */
+                if (
+                    defined('DOING_AJAX') && DOING_AJAX &&
+                    isset($_POST['action']) && $_POST['action'] === 'inline-save'
+                ) {
+                    $_POST['sticky'] = true;
+                } else {
+                    $postModel = call_user_func($this->expirablePostModelFactory, $postId);
+                    $postModel->stick();
+                }
 
                 $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
 

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/StickPostRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/StickPostRunner.php
@@ -50,30 +50,51 @@ class StickPostRunner implements StepRunnerInterface
         $this->stepProcessor->executeSafelyWithErrorHandling(
             $step,
             function ($step, $postId) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $stickUsingTheModel = true;
+
+                $isQuickEdit = defined('DOING_AJAX')
+                    && DOING_AJAX
+                    && isset($_POST['action'])
+                    && $_POST['action'] === 'inline-save';
+
+                $isClassicEditor = ( ! defined('DOING_AJAX') || ! DOING_AJAX)
+                    && isset($_POST['action'])
+                    && $_POST['action'] === 'editpost';
+
                 /*
-                 * Handle quick-edit saving, otherwise it will override the sticky status at the end of the save
+                 * Handle quick-edit or classic editor saving, otherwise it will override
+                 * the sticky status at the end of the save.
                  *
                  * @see https://github.com/publishpress/PublishPress-Future/issues/1204
                  */
-                if (
-                    defined('DOING_AJAX') && DOING_AJAX &&
-                    isset($_POST['action']) && $_POST['action'] === 'inline-save'
-                ) {
+                if ($isQuickEdit || $isClassicEditor) {
                     $_POST['sticky'] = true;
-                } else {
-                    $postModel = call_user_func($this->expirablePostModelFactory, $postId);
-                    $postModel->stick();
+
+                    $stickUsingTheModel = false;
+
+                    $this->logger->debug(
+                        $this->stepProcessor->prepareLogMessage(
+                            'Post %1$s sticked on %2$s setting sticky status via POST',
+                            $postId,
+                            $nodeSlug
+                        )
+                    );
                 }
 
-                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+                if ($stickUsingTheModel) {
+                    $postModel = call_user_func($this->expirablePostModelFactory, $postId);
+                    $postModel->stick();
 
-                $this->logger->debug(
-                    $this->stepProcessor->prepareLogMessage(
-                        'Post %1$s sticked on step %2$s',
-                        $postId,
-                        $nodeSlug
-                    )
-                );
+                    $this->logger->debug(
+                        $this->stepProcessor->prepareLogMessage(
+                            'Post %1$s sticked on step %2$s using the model',
+                            $postId,
+                            $nodeSlug
+                        )
+                    );
+                }
             },
             $postId
         );

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/UnstickPostRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/UnstickPostRunner.php
@@ -49,30 +49,51 @@ class UnstickPostRunner implements StepRunnerInterface
         $this->stepProcessor->executeSafelyWithErrorHandling(
             $step,
             function ($step, $postId) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $unstickUsingTheModel = true;
+
+                $isQuickEdit = defined('DOING_AJAX')
+                    && DOING_AJAX
+                    && isset($_POST['action'])
+                    && $_POST['action'] === 'inline-save';
+
+                $isClassicEditor = ( ! defined('DOING_AJAX') || ! DOING_AJAX)
+                    && isset($_POST['action'])
+                    && $_POST['action'] === 'editpost';
+
                 /*
-                 * Handle quick-edit saving, otherwise it will override the sticky status at the end of the save
+                 * Handle quick-edit or classic editor saving, otherwise it will override
+                 * the sticky status at the end of the save.
                  *
                  * @see https://github.com/publishpress/PublishPress-Future/issues/1204
                  */
-                if (
-                    defined('DOING_AJAX') && DOING_AJAX &&
-                    isset($_POST['action']) && $_POST['action'] === 'inline-save'
-                ) {
+                if ($isQuickEdit || $isClassicEditor) {
                     $_POST['sticky'] = false;
-                } else {
-                    $postModel = call_user_func($this->expirablePostModelFactory, $postId);
-                    $postModel->unstick();
+
+                    $unstickUsingTheModel = false;
+
+                    $this->logger->debug(
+                        $this->stepProcessor->prepareLogMessage(
+                            'Post %1$s unsticked on %2$s setting sticky status via POST',
+                            $postId,
+                            $nodeSlug
+                        )
+                    );
                 }
 
-                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+                if ($unstickUsingTheModel) {
+                    $postModel = call_user_func($this->expirablePostModelFactory, $postId);
+                    $postModel->unstick();
 
-                $this->logger->debug(
-                    $this->stepProcessor->prepareLogMessage(
-                        'Post %1$s unstick on step %2$s',
-                        $postId,
-                        $nodeSlug
-                    )
-                );
+                    $this->logger->debug(
+                        $this->stepProcessor->prepareLogMessage(
+                            'Post %1$s unsticked on step %2$s using the model',
+                            $postId,
+                            $nodeSlug
+                        )
+                    );
+                }
             },
             $postId
         );

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/UnstickPostRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/UnstickPostRunner.php
@@ -49,8 +49,20 @@ class UnstickPostRunner implements StepRunnerInterface
         $this->stepProcessor->executeSafelyWithErrorHandling(
             $step,
             function ($step, $postId) {
-                $postModel = call_user_func($this->expirablePostModelFactory, $postId);
-                $postModel->unstick();
+                /*
+                 * Handle quick-edit saving, otherwise it will override the sticky status at the end of the save
+                 *
+                 * @see https://github.com/publishpress/PublishPress-Future/issues/1204
+                 */
+                if (
+                    defined('DOING_AJAX') && DOING_AJAX &&
+                    isset($_POST['action']) && $_POST['action'] === 'inline-save'
+                ) {
+                    $_POST['sticky'] = false;
+                } else {
+                    $postModel = call_user_func($this->expirablePostModelFactory, $postId);
+                    $postModel->unstick();
+                }
 
                 $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
 


### PR DESCRIPTION
Updated changelog to reflect this change. Removed unnecessary validation rules for improved clarity in workflow execution.