### PR TITLE
"Required" issue if "Remove all terms" is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Settings Controller processes form submissions on every admin page load (Issue #1310).
+- Fixed validation issue in the workflow editor where selecting "Remove all terms" not removing required error (Issue #1244).
+
 
 ### Removed
 

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/RemovePostTerm.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/RemovePostTerm.php
@@ -120,6 +120,10 @@ class RemovePostTerm implements StepTypeInterface
                         "rule" => "required",
                         "field" => "taxonomyTerms.terms",
                         "label" => __("Terms", "post-expirator"),
+                        "condition" => [
+                            "field" => "taxonomyTerms.selectAll",
+                            "value" => "0"
+                        ]
                     ],
                     [
                         "rule" => "validVariable",


### PR DESCRIPTION
Fixed validation issue in the workflow editor where selecting "Remove all terms" not removing required error by adding validation condition to consider `taxonomyTerms.selectAll` as valid value to fix #1244