### PR TITLE
Stop automatic cancelation of scheduled actions when a workflow is disabled, and add manual option for doing that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added a "Copy" button to workflows (Issue #1183).
+- Added a "Cancel Scheduled Actions" button to workflows lists (Issue #1326).
 
 ### Changed
 
 - Stick and Unstick Post workflow steps can now be used anywhere in workflows, not just within Schedule branches (Issue #1204).
+- Stop automatic cancelation of scheduled actions when a workflow is disabled in support of manual button, (Issue #1326).
 
 ### Fixed
 

--- a/assets/jsx/workflows-list/cancel-action/index.jsx
+++ b/assets/jsx/workflows-list/cancel-action/index.jsx
@@ -1,0 +1,87 @@
+import { useState, useEffect, useCallback, render } from '@wordpress/element';
+import { Modal, Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import './style.css';
+
+const CancelActionsConfirmation = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [actionData, setActionData] = useState({
+        link: '',
+        title: ''
+    });
+
+    const handleCancelActionsClick = useCallback((e) => {
+        e.preventDefault();
+        const link = e.target.href;
+        const title = e.target.dataset.workflowTitle || '';
+        setActionData({ link, title });
+        setIsOpen(true);
+    }, []);
+
+    useEffect(() => {
+        const cancelLinks = document.querySelectorAll('.pp-future-workflow-cancel-actions');
+
+        cancelLinks.forEach(link => {
+            link.addEventListener('click', handleCancelActionsClick);
+        });
+
+        return () => {
+            cancelLinks.forEach(link => {
+                link.removeEventListener('click', handleCancelActionsClick);
+            });
+        };
+    }, [handleCancelActionsClick]);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const handleConfirm = () => {
+        window.location.href = actionData.link;
+    };
+
+    return (
+        <Modal
+            title={__('Cancel Scheduled Actions', 'post-expirator')}
+            onRequestClose={() => setIsOpen(false)}
+            className="pp-future-cancel-actions-modal"
+            style={{ maxWidth: '400px' }}
+        >
+            <p>
+                {sprintf(
+                    // translators: %s: Workflow title
+                    __('Are you sure you want to cancel all scheduled actions for the "%s" workflow?', 'post-expirator'),
+                    actionData.title
+                )}
+            </p>
+            <div className="pp-future-cancel-actions-buttons">
+                <Button
+                    variant="secondary"
+                    isDestructive={true}
+                    onClick={handleConfirm}
+                >
+                    {__('Cancel Actions', 'post-expirator')}
+                </Button>
+                <Button
+                    variant="secondary"
+                    onClick={() => setIsOpen(false)}
+                >
+                    {__('No', 'post-expirator')}
+                </Button>
+            </div>
+        </Modal>
+    );
+};
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    // Create container and render
+    const modalContainer = document.createElement('div');
+    modalContainer.id = 'pp-future-cancel-actions-container';
+    document.body.appendChild(modalContainer);
+
+    render(
+        <CancelActionsConfirmation />,
+        modalContainer
+    );
+});

--- a/assets/jsx/workflows-list/cancel-action/index.jsx
+++ b/assets/jsx/workflows-list/cancel-action/index.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback, render } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { Modal, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { createRoot } from 'react-dom/client';
 import './style.css';
 
 const CancelActionsConfirmation = () => {
@@ -32,7 +33,7 @@ const CancelActionsConfirmation = () => {
         };
     }, [handleCancelActionsClick]);
 
-    if (!isOpen) {
+    if (! isOpen) {
         return null;
     }
 
@@ -75,13 +76,11 @@ const CancelActionsConfirmation = () => {
 
 // Initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
-    // Create container and render
+    // Create container
     const modalContainer = document.createElement('div');
     modalContainer.id = 'pp-future-cancel-actions-container';
     document.body.appendChild(modalContainer);
-
-    render(
-        <CancelActionsConfirmation />,
-        modalContainer
-    );
+    // Render the container
+    const root = createRoot(modalContainer);
+    root.render(<CancelActionsConfirmation />);
 });

--- a/assets/jsx/workflows-list/cancel-action/style.css
+++ b/assets/jsx/workflows-list/cancel-action/style.css
@@ -1,0 +1,4 @@
+.pp-future-cancel-actions-buttons {
+    display: flex;
+    justify-content: space-between;
+}

--- a/src/Modules/Workflows/Controllers/WorkflowsList.php
+++ b/src/Modules/Workflows/Controllers/WorkflowsList.php
@@ -10,6 +10,7 @@ use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypesModelInterface;
 use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
 use PublishPress\Future\Modules\Workflows\Models\WorkflowModel;
+use PublishPress\Future\Modules\Workflows\Models\ScheduledActionsModel;
 use PublishPress\Future\Modules\Workflows\Module;
 use PublishPress\Future\Framework\Logger\LoggerInterface;
 use PublishPress\Future\Modules\Settings\SettingsFacade;
@@ -129,12 +130,17 @@ class WorkflowsList implements InitializableInterface
 
         $this->hooks->addAction(
             CoreHooksAbstract::ACTION_ADMIN_NOTICES,
-            [$this, 'showWorkflowCopyNotice']
+            [$this, 'showWorkflowsNotice']
         );
 
         $this->hooks->addFilter(
             CoreHooksAbstract::FILTER_REMOVABLE_QUERY_ARGS,
             [$this, 'addRemovableQueryArgs']
+        );
+
+        $this->hooks->addAction(
+            CoreHooksAbstract::ACTION_ADMIN_INIT,
+            [$this, "handleCancelScheduledActions"]
         );
     }
 
@@ -378,8 +384,8 @@ class WorkflowsList implements InitializableInterface
             return $actions;
         }
 
-        $actions = [
-            // Add status action
+        // New Action for status
+        $newActions = [
             $statusData['action'] => sprintf(
                 '<a href="%s" class="pp-future-workflow-%s-inline" title="%s">%s</a>',
                 esc_url(
@@ -398,26 +404,51 @@ class WorkflowsList implements InitializableInterface
                 $statusData['action'],
                 $statusData['text'],
                 $statusData['title']
-            ),
-            // Add copy action
-            'copy' => sprintf(
-                '<a href="%s" class="pp-future-workflow-copy-inline" title="%s">%s</a>',
+            )
+        ];
+
+        if ($workflowStatus !== 'publish') {
+            // add cancel scheduled actions
+            $newActions['cancel_scheduled_actions'] = sprintf(
+                '<a href="%s" class="pp-future-workflow-cancel-actions" title="%s" data-workflow-title="%s">%s</a>',
                 esc_url(
                     wp_nonce_url(
                         add_query_arg(
                             [
-                                'pp_action' => 'copy_workflow',
+                                'pp_action' => 'cancel_workflow_scheduled_actions',
                                 'workflow_id' => $post->ID
                             ],
                             admin_url('edit.php?post_type=' . Module::POST_TYPE_WORKFLOW)
                         ),
-                        'copy_workflow_' . $post->ID
+                        'cancel_workflow_scheduled_actions_' . $post->ID
                     )
                 ),
-                __('Copy this workflow', 'post-expirator'),
-                __('Copy', 'post-expirator')
+                __('Cancel all actions scheduled for this workflow', 'post-expirator'),
+                esc_attr($post->post_title),
+                __('Cancel Scheduled Actions', 'post-expirator'),
+            );
+        }
+
+        // add copy action
+        $newActions['copy'] = sprintf(
+            '<a href="%s" class="pp-future-workflow-copy-inline" title="%s">%s</a>',
+            esc_url(
+                wp_nonce_url(
+                    add_query_arg(
+                        [
+                            'pp_action' => 'copy_workflow',
+                            'workflow_id' => $post->ID
+                        ],
+                        admin_url('edit.php?post_type=' . Module::POST_TYPE_WORKFLOW)
+                    ),
+                    'copy_workflow_' . $post->ID
+                )
             ),
-        ] + $actions;
+            __('Copy this workflow', 'post-expirator'),
+            __('Copy', 'post-expirator')
+        );
+
+        $actions = $newActions + $actions;
 
         return $actions;
     }
@@ -505,6 +536,102 @@ class WorkflowsList implements InitializableInterface
         }
     }
 
+    public function handleCancelScheduledActions()
+    {
+
+        $postType = Module::POST_TYPE_WORKFLOW;
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if (!isset($_GET['post_type']) || $_GET['post_type'] !== $postType) {
+            return;
+        }
+
+        if (!isset($_GET['pp_action']) || 'cancel_workflow_scheduled_actions' !== $_GET['pp_action']) {
+            return;
+        }
+
+        try {
+            if (!isset($_GET['workflow_id'])) {
+                return;
+            }
+
+            if (!isset($_GET['_wpnonce'])) {
+                return;
+            }
+
+            if (!wp_verify_nonce(sanitize_key($_GET['_wpnonce']), 'cancel_workflow_scheduled_actions_' . (int) $_GET['workflow_id'])) {
+                return;
+            }
+
+            $redirect_url = admin_url('edit.php?post_type=' . $postType);
+            $workflowId = (int) $_GET['workflow_id'];
+
+            // Check if workflow is disabled
+            $workflowModel = new WorkflowModel();
+            $workflowModel->load($workflowId);
+
+            if ($workflowModel->getStatus() === 'publish') {
+                $redirect_url = add_query_arg(
+                    [
+                        'pp_workflow_notice' => 'scheduled_action_cancelling_status_error',
+                        'pp_workflow_notice_type' => 'error'
+                    ],
+                    $redirect_url
+                );
+                wp_safe_redirect(
+                    esc_url_raw($redirect_url)
+                );
+                exit;
+            }
+
+            $scheduledActionsModel = new ScheduledActionsModel();
+
+            // Check if workflow has scheduled actions
+            $hasScheduledActions = $scheduledActionsModel->workflowHasScheduledActions($workflowId);
+            if (!$hasScheduledActions) {
+                $redirect_url = add_query_arg(
+                    [
+                        'pp_workflow_notice' => 'scheduled_action_cancelling_empty',
+                        'pp_workflow_notice_type' => 'error'
+                    ],
+                    $redirect_url
+                );
+                wp_safe_redirect(
+                    esc_url_raw($redirect_url)
+                );
+                exit;
+            }
+
+            // Cancel scheduled actions
+            $scheduledActionsModel->cancelWorkflowScheduledActions($workflowId);
+
+            // Redirect back to the workflows list with a success message
+            $redirect_url = add_query_arg(
+                [
+                    'pp_workflow_notice' => 'scheduled_action_cancelling_success',
+                    'pp_workflow_notice_type' => 'success'
+                ],
+                $redirect_url
+            );
+            wp_safe_redirect(
+                esc_url_raw($redirect_url)
+            );
+            exit;
+        } catch (Throwable $th) {
+            $redirect_url = add_query_arg(
+                [
+                    'pp_workflow_notice' => 'scheduled_action_cancelling_error',
+                    'pp_workflow_notice_type' => 'error'
+                ],
+                $redirect_url
+            );
+            wp_safe_redirect(
+                esc_url_raw($redirect_url)
+            );
+            exit;
+        }
+    }
+
     public function addRemovableQueryArgs($args)
     {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -517,7 +644,7 @@ class WorkflowsList implements InitializableInterface
         return $args;
     }
 
-    public function showWorkflowCopyNotice()
+    public function showWorkflowsNotice()
     {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
         if (!isset($_GET['post_type']) || $_GET['post_type'] !== Module::POST_TYPE_WORKFLOW) {
@@ -536,12 +663,20 @@ class WorkflowsList implements InitializableInterface
 
         $messages = [
             'error' => [
+                // Copy workflow error
                 'source_not_found'  => __('Source workflow not found.', 'post-expirator'),
                 'create_failed'     => __('Failed to create new workflow.', 'post-expirator'),
-                'generic_error'     => __('An error occurred while copying the workflow.', 'post-expirator')
+                'generic_error'     => __('An error occurred while copying the workflow.', 'post-expirator'),
+                // Cancel  cheduled workflow error
+                'scheduled_action_cancelling_status_error'  =>  __('Cannot cancel scheduled actions for an active workflow.', 'post-expirator'),
+                'scheduled_action_cancelling_error'         =>  __('Error cancelling scheduled actions.', 'post-expirator'),
+                'scheduled_action_cancelling_empty'         =>  __('This workflow doesn\'t have any scheduled action.', 'post-expirator')
             ],
             'success' => [
-                'copy_success'      => __('Workflow copied successfully.', 'post-expirator')
+                // Copy workflow success
+                'copy_success'  => __('Workflow copied successfully.', 'post-expirator'),
+                // Cancel scheduled workflow success
+                'scheduled_action_cancelling_success' => __('Scheduled actions have been cancelled successfully.', 'post-expirator')
             ]
         ];
 

--- a/src/Modules/Workflows/Controllers/WorkflowsList.php
+++ b/src/Modules/Workflows/Controllers/WorkflowsList.php
@@ -202,6 +202,14 @@ class WorkflowsList implements InitializableInterface
             [],
             PUBLISHPRESS_FUTURE_VERSION
         );
+
+        wp_enqueue_script(
+            'pp-future-workflows-list-cancel-actions',
+            Plugin::getAssetUrl('js/workflowsListCancelAction.js'),
+            ['wp-element', 'wp-components', 'wp-i18n'],
+            PUBLISHPRESS_FUTURE_VERSION,
+            true
+        );
     }
 
     public function addCustomColumns($columns)
@@ -455,7 +463,6 @@ class WorkflowsList implements InitializableInterface
 
     public function copyWorkflow()
     {
-
         $postType = Module::POST_TYPE_WORKFLOW;
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -538,7 +545,6 @@ class WorkflowsList implements InitializableInterface
 
     public function handleCancelScheduledActions()
     {
-
         $postType = Module::POST_TYPE_WORKFLOW;
 
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -559,7 +565,12 @@ class WorkflowsList implements InitializableInterface
                 return;
             }
 
-            if (!wp_verify_nonce(sanitize_key($_GET['_wpnonce']), 'cancel_workflow_scheduled_actions_' . (int) $_GET['workflow_id'])) {
+            if (
+                !wp_verify_nonce(
+                    sanitize_key($_GET['_wpnonce']),
+                    'cancel_workflow_scheduled_actions_' . (int) $_GET['workflow_id']
+                )
+            ) {
                 return;
             }
 
@@ -667,7 +678,7 @@ class WorkflowsList implements InitializableInterface
                 'source_not_found'  => __('Source workflow not found.', 'post-expirator'),
                 'create_failed'     => __('Failed to create new workflow.', 'post-expirator'),
                 'generic_error'     => __('An error occurred while copying the workflow.', 'post-expirator'),
-                // Cancel  cheduled workflow error
+                // Cancel  scheduled workflow error
                 'scheduled_action_cancelling_status_error'  =>  __('Cannot cancel scheduled actions for an active workflow.', 'post-expirator'),
                 'scheduled_action_cancelling_error'         =>  __('Error cancelling scheduled actions.', 'post-expirator'),
                 'scheduled_action_cancelling_empty'         =>  __('This workflow doesn\'t have any scheduled action.', 'post-expirator')

--- a/src/Modules/Workflows/Domain/Engine/WorkflowEngine.php
+++ b/src/Modules/Workflows/Domain/Engine/WorkflowEngine.php
@@ -427,18 +427,10 @@ class WorkflowEngine implements WorkflowEngineInterface
 
         if ($newPost->post_status === 'publish') {
             $this->onWorkflowPublished($workflowId);
-        } else {
-            $this->onWorkflowUnpublished($workflowId);
         }
     }
 
     public function onWorkflowPublished($workflowId)
-    {
-        $scheduledActionsModel = new ScheduledActionsModel();
-        $scheduledActionsModel->cancelWorkflowScheduledActions($workflowId);
-    }
-
-    public function onWorkflowUnpublished($workflowId)
     {
         $scheduledActionsModel = new ScheduledActionsModel();
         $scheduledActionsModel->cancelWorkflowScheduledActions($workflowId);

--- a/src/Modules/Workflows/Interfaces/ScheduledActionsModelInterface.php
+++ b/src/Modules/Workflows/Interfaces/ScheduledActionsModelInterface.php
@@ -33,4 +33,9 @@ interface ScheduledActionsModelInterface
      * @since 4.3.2
      */
     public function cancelByWorkflowAndPostId(int $workflowId, int $postId): void;
+
+    /**
+     * @since 4.7.0
+     */
+    public function workflowHasScheduledActions(int $workflowId): bool;
 }

--- a/src/Modules/Workflows/Models/ScheduledActionsModel.php
+++ b/src/Modules/Workflows/Models/ScheduledActionsModel.php
@@ -287,7 +287,7 @@ class ScheduledActionsModel implements ScheduledActionsModelInterface
         }
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching
-        $count = $wpdb->get_var(
+        $queryCount = $wpdb->get_var(
             $wpdb->prepare(
                 "SELECT COUNT(*)
                 FROM %i AS wss
@@ -300,6 +300,8 @@ class ScheduledActionsModel implements ScheduledActionsModelInterface
             )
         );
 
-        return (int)$count > 0;
+        $count = (int) $queryCount;
+
+        return $count > 0;
     }
 }

--- a/src/Modules/Workflows/Models/ScheduledActionsModel.php
+++ b/src/Modules/Workflows/Models/ScheduledActionsModel.php
@@ -274,4 +274,32 @@ class ScheduledActionsModel implements ScheduledActionsModelInterface
             )
         );
     }
+
+    public function workflowHasScheduledActions(int $workflowId): bool
+    {
+        global $wpdb;
+
+        $container = Container::getInstance();
+        $tableSchema = $container->get(ServicesAbstract::DB_TABLE_WORKFLOW_SCHEDULED_STEPS_SCHEMA);
+
+        if (!$tableSchema->isTableExistent()) {
+            return false;
+        }
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching
+        $count = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*)
+                FROM %i AS wss
+                INNER JOIN %i AS asa ON wss.action_id = asa.action_id
+                WHERE wss.workflow_id = %d AND asa.status = 'pending' AND asa.group_id = %d",
+                $tableSchema->getTableName(),
+                $wpdb->prefix . 'actionscheduler_actions',
+                $workflowId,
+                $this->getGroupID()
+            )
+        );
+
+        return (int)$count > 0;
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,8 @@ module.exports = {
         workflowManualSelectionBlockEditor: "./assets/jsx/workflow-manual-selection/block-editor/index.jsx",
         workflowManualSelectionBulkEdit: "./assets/jsx/workflow-manual-selection/bulk-edit/index.jsx",
         futureActions: "./assets/jsx/future-actions.jsx",
-        backupPanel: "./assets/jsx/backup-panel/index.jsx"
+        backupPanel: "./assets/jsx/backup-panel/index.jsx",
+        workflowsListCancelAction: "./assets/jsx/workflows-list/cancel-action/index.jsx"
     },
     output: {
         path: path.join(__dirname, "assets", "js"),


### PR DESCRIPTION
Stop automatic cancelation of scheduled actions when a workflow is disabled in support of manual button to fix #1326