### PR TITLE
Improve consistency on the name of manually enabled triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.8.0]- UNRELEASED
+
+### Changed
+
+- Improve consistency on the name of manually enabled triggers (Issue #1366).
+
 ## [4.7.1]- 11 June, 2025
 
 ### Fixed

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnLegacyActionTrigger.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnLegacyActionTrigger.php
@@ -51,7 +51,7 @@ class OnLegacyActionTrigger implements StepTypeInterface
 
     public function getLabel(): string
     {
-        return __("Manually enabled via Future Actions box", "post-expirator");
+        return __("Manually run via Future Actions box", "post-expirator");
     }
 
     public function getDescription(): string

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnPostWorkflowEnable.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnPostWorkflowEnable.php
@@ -29,7 +29,7 @@ class OnPostWorkflowEnable implements StepTypeInterface
 
     public function getLabel(): string
     {
-        return __("Manually enabled via checkbox", "post-expirator");
+        return __("Manually run via checkbox", "post-expirator");
     }
 
     public function getDescription(): string


### PR DESCRIPTION
Improve consistency on the name of manually enabled triggers to fix #1366