### PR TITLE
Set default Workflow to first option for "Deactivate Workflow for Post" Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.8.0]- UNRELEASED
+
+### Changed
+
+- Changed the default value of "Workflow" field in the "Deactivate workflow for post" action to automatically select the first available workflow option (Issue #958).
+
 ## [4.7.1]- 11 June, 2025
 
 ### Fixed

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/DeactivatePostWorkflow.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/DeactivatePostWorkflow.php
@@ -86,7 +86,10 @@ class DeactivatePostWorkflow implements StepTypeInterface
                         "name" => "workflow",
                         "type" => "manualWorkflowInput",
                         "default" => [
-                            "variable" => "global.workflow",
+                            "variable" => [
+                                "rule" => "first",
+                                "dataType" => "workflow",
+                            ]
                         ],
                         "label" => __("Workflow to Deactivate", "post-expirator"),
                         "description" => __(


### PR DESCRIPTION
Changed the default value of "Workflow" field in the "Deactivate workflow for post" action to automatically select the first available workflow option to fix #958