### PR TITLE
Error with WooCommerce and the On Custom Action trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update the field description Text on User interaction step (Issue #1384).
 - Consistency with "Filters" name (Issue #1296).
 
+### Fixed
+
+- Fixed WooCommerce Order Notice: Function ID was called incorrectly. Order properties should not be accessed directly (Issue #1388).
+
 ## [4.7.1]- 11 June, 2025
 
 ### Fixed

--- a/src/Modules/Expirator/Controllers/ClassicEditorController.php
+++ b/src/Modules/Expirator/Controllers/ClassicEditorController.php
@@ -92,12 +92,10 @@ class ClassicEditorController implements InitializableInterface
                 $id = $post->ID;
             } elseif (isset($post->post_id)) {
                 $id = $post->post_id;
+            } elseif (method_exists($post, 'get_id')) {
+                $id = $post->get_id();
             } elseif (isset($post->id)) {
                 $id = $post->id;
-            } else {
-                if (method_exists($post, 'get_id')) {
-                    $id = $post->get_id();
-                }
             }
 
             if (! is_null($id)) {


### PR DESCRIPTION
Fixed WooCommerce Order Notice: Function ID was called incorrectly. Order properties should not be accessed directly to fix Issue #1388