### PR TITLE
"On custom action" and "Do custom action" name consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improve consistency on the name of manually enabled triggers (Issue #1366).
 - Update the field description Text on User interaction step (Issue #1384).
 - Consistency with "Filters" name (Issue #1296).
+- Workflow name consistency, update "Custom action" to "Do custom action" (Issue #1385).
 
 ### Fixed
 

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/DoAction.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/DoAction.php
@@ -29,12 +29,12 @@ class DoAction implements StepTypeInterface
 
     public function getLabel(): string
     {
-        return __("Do action", "post-expirator");
+        return __("Do custom action", "post-expirator");
     }
 
     public function getDescription(): string
     {
-        return __("This step executes an action.", "post-expirator");
+        return __("This step executes a custom action.", "post-expirator");
     }
 
     public function getIcon(): string


### PR DESCRIPTION
Workflow name consistency, update "Custom action" to "Do custom action" to fix #1385