### PR TITLE
Conflict in WordPress 6.8.2 breaking post editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.8.1]- [UNRELEASED]
+
+### Fixed
+
+- Conflict in WordPress 6.8.2 breaking post editor, (Issue #1404).
+
 ## [4.8.0]- 09 July, 2025
 
 ### Added

--- a/assets/js/blockEditor.js
+++ b/assets/js/blockEditor.js
@@ -743,14 +743,12 @@ var FutureActionPanelBlockEditor = function FutureActionPanelBlockEditor(props) 
     var newAttribute = {
       'enabled': store.getEnabled()
     };
-    if (newAttribute.enabled) {
-      newAttribute['action'] = store.getAction();
-      newAttribute['newStatus'] = store.getNewStatus();
-      newAttribute['date'] = store.getDate();
-      newAttribute['terms'] = store.getTerms();
-      newAttribute['taxonomy'] = store.getTaxonomy();
-      newAttribute['extraData'] = store.getExtraData();
-    }
+    newAttribute['action'] = store.getAction();
+    newAttribute['newStatus'] = store.getNewStatus();
+    newAttribute['date'] = store.getDate();
+    newAttribute['terms'] = store.getTerms();
+    newAttribute['taxonomy'] = store.getTaxonomy();
+    newAttribute['extraData'] = store.getExtraData();
     editPostAttribute(newAttribute);
   };
   var rawData = select('core/editor').getEditedPostAttribute('publishpress_future_action');

--- a/assets/js/bulkEdit.js
+++ b/assets/js/bulkEdit.js
@@ -743,14 +743,12 @@ var FutureActionPanelBlockEditor = function FutureActionPanelBlockEditor(props) 
     var newAttribute = {
       'enabled': store.getEnabled()
     };
-    if (newAttribute.enabled) {
-      newAttribute['action'] = store.getAction();
-      newAttribute['newStatus'] = store.getNewStatus();
-      newAttribute['date'] = store.getDate();
-      newAttribute['terms'] = store.getTerms();
-      newAttribute['taxonomy'] = store.getTaxonomy();
-      newAttribute['extraData'] = store.getExtraData();
-    }
+    newAttribute['action'] = store.getAction();
+    newAttribute['newStatus'] = store.getNewStatus();
+    newAttribute['date'] = store.getDate();
+    newAttribute['terms'] = store.getTerms();
+    newAttribute['taxonomy'] = store.getTaxonomy();
+    newAttribute['extraData'] = store.getExtraData();
     editPostAttribute(newAttribute);
   };
   var rawData = select('core/editor').getEditedPostAttribute('publishpress_future_action');

--- a/assets/js/classicEditor.js
+++ b/assets/js/classicEditor.js
@@ -743,14 +743,12 @@ var FutureActionPanelBlockEditor = function FutureActionPanelBlockEditor(props) 
     var newAttribute = {
       'enabled': store.getEnabled()
     };
-    if (newAttribute.enabled) {
-      newAttribute['action'] = store.getAction();
-      newAttribute['newStatus'] = store.getNewStatus();
-      newAttribute['date'] = store.getDate();
-      newAttribute['terms'] = store.getTerms();
-      newAttribute['taxonomy'] = store.getTaxonomy();
-      newAttribute['extraData'] = store.getExtraData();
-    }
+    newAttribute['action'] = store.getAction();
+    newAttribute['newStatus'] = store.getNewStatus();
+    newAttribute['date'] = store.getDate();
+    newAttribute['terms'] = store.getTerms();
+    newAttribute['taxonomy'] = store.getTaxonomy();
+    newAttribute['extraData'] = store.getExtraData();
     editPostAttribute(newAttribute);
   };
   var rawData = select('core/editor').getEditedPostAttribute('publishpress_future_action');

--- a/assets/js/quickEdit.js
+++ b/assets/js/quickEdit.js
@@ -743,14 +743,12 @@ var FutureActionPanelBlockEditor = function FutureActionPanelBlockEditor(props) 
     var newAttribute = {
       'enabled': store.getEnabled()
     };
-    if (newAttribute.enabled) {
-      newAttribute['action'] = store.getAction();
-      newAttribute['newStatus'] = store.getNewStatus();
-      newAttribute['date'] = store.getDate();
-      newAttribute['terms'] = store.getTerms();
-      newAttribute['taxonomy'] = store.getTaxonomy();
-      newAttribute['extraData'] = store.getExtraData();
-    }
+    newAttribute['action'] = store.getAction();
+    newAttribute['newStatus'] = store.getNewStatus();
+    newAttribute['date'] = store.getDate();
+    newAttribute['terms'] = store.getTerms();
+    newAttribute['taxonomy'] = store.getTaxonomy();
+    newAttribute['extraData'] = store.getExtraData();
     editPostAttribute(newAttribute);
   };
   var rawData = select('core/editor').getEditedPostAttribute('publishpress_future_action');

--- a/assets/js/settingsGeneral.js
+++ b/assets/js/settingsGeneral.js
@@ -743,14 +743,12 @@ var FutureActionPanelBlockEditor = function FutureActionPanelBlockEditor(props) 
     var newAttribute = {
       'enabled': store.getEnabled()
     };
-    if (newAttribute.enabled) {
-      newAttribute['action'] = store.getAction();
-      newAttribute['newStatus'] = store.getNewStatus();
-      newAttribute['date'] = store.getDate();
-      newAttribute['terms'] = store.getTerms();
-      newAttribute['taxonomy'] = store.getTaxonomy();
-      newAttribute['extraData'] = store.getExtraData();
-    }
+    newAttribute['action'] = store.getAction();
+    newAttribute['newStatus'] = store.getNewStatus();
+    newAttribute['date'] = store.getDate();
+    newAttribute['terms'] = store.getTerms();
+    newAttribute['taxonomy'] = store.getTaxonomy();
+    newAttribute['extraData'] = store.getExtraData();
     editPostAttribute(newAttribute);
   };
   var rawData = select('core/editor').getEditedPostAttribute('publishpress_future_action');

--- a/assets/js/settingsPostTypes.js
+++ b/assets/js/settingsPostTypes.js
@@ -743,14 +743,12 @@ var FutureActionPanelBlockEditor = function FutureActionPanelBlockEditor(props) 
     var newAttribute = {
       'enabled': store.getEnabled()
     };
-    if (newAttribute.enabled) {
-      newAttribute['action'] = store.getAction();
-      newAttribute['newStatus'] = store.getNewStatus();
-      newAttribute['date'] = store.getDate();
-      newAttribute['terms'] = store.getTerms();
-      newAttribute['taxonomy'] = store.getTaxonomy();
-      newAttribute['extraData'] = store.getExtraData();
-    }
+    newAttribute['action'] = store.getAction();
+    newAttribute['newStatus'] = store.getNewStatus();
+    newAttribute['date'] = store.getDate();
+    newAttribute['terms'] = store.getTerms();
+    newAttribute['taxonomy'] = store.getTaxonomy();
+    newAttribute['extraData'] = store.getExtraData();
     editPostAttribute(newAttribute);
   };
   var rawData = select('core/editor').getEditedPostAttribute('publishpress_future_action');

--- a/assets/jsx/components/FutureActionPanelBlockEditor.jsx
+++ b/assets/jsx/components/FutureActionPanelBlockEditor.jsx
@@ -27,14 +27,12 @@ export const FutureActionPanelBlockEditor = (props) => {
             'enabled': store.getEnabled()
         }
 
-        if (newAttribute.enabled) {
-            newAttribute['action'] = store.getAction();
-            newAttribute['newStatus'] = store.getNewStatus();
-            newAttribute['date'] = store.getDate();
-            newAttribute['terms'] = store.getTerms();
-            newAttribute['taxonomy'] = store.getTaxonomy();
-            newAttribute['extraData'] = store.getExtraData();
-        }
+        newAttribute['action'] = store.getAction();
+        newAttribute['newStatus'] = store.getNewStatus();
+        newAttribute['date'] = store.getDate();
+        newAttribute['terms'] = store.getTerms();
+        newAttribute['taxonomy'] = store.getTaxonomy();
+        newAttribute['extraData'] = store.getExtraData();
 
         editPostAttribute(newAttribute);
     }


### PR DESCRIPTION
This PR Fixed Conflict in WordPress 6.8.2 breaking post editor by making sure all other future action attributes are still saved either the action is enabled or disabled since it's the status that really determine if the action will be schedule or not to fix #1404