### PR TITLE
Bug Report 4.8.0 (Post is null or ID is not set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Conflict in WordPress 6.8.2 breaking post editor, (Issue #1404).
+- PHP message: PUBLISHPRESS FUTURE - Error registering classic editor metabox: Post is null or ID is not set, cannot load workflows" while reading response header from upstream, (Issue #1407).
 
 ## [4.8.0]- 09 July, 2025
 

--- a/src/Modules/Expirator/Controllers/ClassicEditorController.php
+++ b/src/Modules/Expirator/Controllers/ClassicEditorController.php
@@ -87,7 +87,7 @@ class ClassicEditorController implements InitializableInterface
 
         // Some 3rd party plugins send the post as an object of a different class.
         // Try to fallback to the WP_Post class looking for the ID.
-        if ((! $post instanceof WP_Post) && is_object($post)) {
+        if ((! is_a($post, 'WP_Post')) && is_object($post)) {
             $id = null;
             if (isset($post->ID)) {
                 $id = $post->ID;
@@ -104,7 +104,7 @@ class ClassicEditorController implements InitializableInterface
             }
         }
 
-        if (! $post instanceof WP_Post) {
+        if (! is_a($post, 'WP_Post')) {
             return false;
         }
 

--- a/src/Modules/Workflows/Controllers/ManualPostTrigger.php
+++ b/src/Modules/Workflows/Controllers/ManualPostTrigger.php
@@ -405,7 +405,7 @@ class ManualPostTrigger implements InitializableInterface
     {
         // Some 3rd party plugins send the post as an object of a different class.
         // Try to fallback to the WP_Post class looking for the ID.
-        if ((! $post instanceof WP_Post) && is_object($post)) {
+        if ((! is_a($post, 'WP_Post')) && is_object($post)) {
             $id = null;
 
             if (isset($post->ID)) {
@@ -423,7 +423,7 @@ class ManualPostTrigger implements InitializableInterface
             }
         }
 
-        if (! $post instanceof WP_Post) {
+        if (! is_a($post, 'WP_Post')) {
             return false;
         }
 


### PR DESCRIPTION
Fixed PHP message: PUBLISHPRESS FUTURE - Error registering classic editor metabox: Post is null or ID is not set, cannot load workflows" while reading response header from upstream to fix #1407