### PR TITLE
Fixed String Translation in SettingsController.php

### DIFF
--- a/src/Modules/Expirator/Controllers/SettingsController.php
+++ b/src/Modules/Expirator/Controllers/SettingsController.php
@@ -319,6 +319,12 @@ class SettingsController implements InitializableInterface
                         'referrer' => esc_html(remove_query_arg('_wp_http_referer')),
                     ]
                 );
+
+                wp_set_script_translations(
+                    'publishpressfuture-settings-panel',
+                    'post-expirator',
+                    PUBLISHPRESS_FUTURE_BASE_PATH . '/languages'
+                );
             }
 
             // phpcs:disable WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
Fixed String Translation in SettingsController.php

Before (pt_BR):

<img width="547" height="271" alt="before-future" src="https://github.com/user-attachments/assets/be6e17df-2f75-407e-996a-6517afac6df6" />

After (pt_BR):

<img width="548" height="271" alt="after-future" src="https://github.com/user-attachments/assets/86a0a707-2763-4e84-83aa-cacb3c952b5c" />
