### PR TITLE
Enhance error handling in TermModel and ExpirablePostModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bulk Edit for Posts produces an empty Future box, (Issue #1302).
 - Newly created workflow "Manually run via Future Actions box" not working, (Issue #1425).
 - Update ES-FR-IT translations (Issues #1445, #1439).
+- PHP message: PHP Fatal error: Uncaught ... NonexistentTermException in ...TermModel.php, (Issue #1442).
 
 ### Removed
 

--- a/src/Framework/WordPress/Models/TermModel.php
+++ b/src/Framework/WordPress/Models/TermModel.php
@@ -56,13 +56,16 @@ class TermModel
 
     /**
      * @return bool
-     * @throws \PublishPress\Future\Framework\WordPress\Exceptions\NonexistentTermException
      */
     public function termExists()
     {
-        $instance = $this->getTermInstance();
+        try {
+            $instance = $this->getTermInstance();
 
-        return is_object($instance);
+            return is_object($instance);
+        } catch (NonexistentTermException $e) {
+            return false;
+        }
     }
 
     public function getTermID()
@@ -71,12 +74,16 @@ class TermModel
     }
 
     /**
-     * @throws \PublishPress\Future\Framework\WordPress\Exceptions\NonexistentTermException
+     * @return string
      */
     public function getName()
     {
-        $term = $this->getTermInstance();
+        try {
+            $term = $this->getTermInstance();
 
-        return $term->name;
+            return $term->name;
+        } catch (NonexistentTermException $e) {
+            return '';
+        }
     }
 }

--- a/src/Modules/Expirator/Models/ExpirablePostModel.php
+++ b/src/Modules/Expirator/Models/ExpirablePostModel.php
@@ -307,6 +307,11 @@ class ExpirablePostModel extends PostModel
             $termModelFactory = $this->termModelFactory;
             $termModel = $termModelFactory($categoryId);
 
+            if (! $termModel->termExists()) {
+                $this->logger->debug('Term model does not exist for category ID: ' . $categoryId);
+                continue;
+            }
+
             $categoryNames[] = $termModel->getName();
         }
 


### PR DESCRIPTION
Cloning @andergmartins PR from PRO repository https://github.com/publishpress/publishpress-future-pro/pull/115

> - Added try-catch blocks in TermModel methods to handle NonexistentTermException, returning false or an empty string when a term does not exist.
> - Updated ExpirablePostModel to log a debug message when a term model does not exist for a given category ID, improving robustness and debugging capabilities.