### PR TITLE
Redirect users to "Action Workflows" screen on plugin activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Re-organize Action Workflows quick edit links, (Issue #1479)
 - Resize workflow editor expression box modal, (Issue #1480)
+- Redirect users to "Action Workflows" screen on plugin activation, (Issue #1454)
 
 ### Developers
 

--- a/src/Modules/Expirator/Controllers/PluginsListController.php
+++ b/src/Modules/Expirator/Controllers/PluginsListController.php
@@ -85,7 +85,7 @@ class PluginsListController implements InitializableInterface
 
         delete_transient(self::TRANSIENT_REDIRECT_AFTER_ACTIVATION);
 
-        wp_safe_redirect(admin_url('admin.php?page=publishpress-future'));
+        wp_safe_redirect(admin_url('edit.php?post_type=ppfuture_workflow'));
         exit;
     }
 }


### PR DESCRIPTION
Redirect users to "Action Workflows" screen on plugin activation fix #1454