### PR TITLE
Add "New user is created" workflow trigger

### DIFF
--- a/assets/css/workflow-editor.css
+++ b/assets/css/workflow-editor.css
@@ -71,6 +71,13 @@ body.admin_page_future_workflow_editor {
     display: none;
 }
 
+/* Extra spacing under token-field boxes (e.g. User roles filter) so the
+   field description doesn't crowd the box. */
+body.js.workflow-editor .components-form-token-field,
+body.admin_page_future_workflow_editor .components-form-token-field {
+    margin-bottom: 16px;
+}
+
 /* workflow editor modal */
 .workflow-editor-modal .components-modal__content {
     margin-bottom: 72px;

--- a/services.php
+++ b/services.php
@@ -115,6 +115,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostUp
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostWorkflowEnableRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnScheduleRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserRoleChangeRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserCreateRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnTermsAddedRunner;
 use PublishPress\Future\Modules\Workflows\HooksAbstract as WorkflowsHooksAbstract;
 use PublishPress\Future\Modules\Workflows\Logger\WorkflowLogger;
@@ -1115,6 +1116,16 @@ return [
                     $stepRunner = new OnUserRoleChangeRunner(
                         $generalStepProcessor,
                         $workflowLogger
+                    );
+                    break;
+
+                case OnUserCreateRunner::getNodeTypeName():
+                    $stepRunner = new OnUserCreateRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $executionContext,
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD)
                     );
                     break;
 

--- a/src/Core/HooksAbstract.php
+++ b/src/Core/HooksAbstract.php
@@ -34,6 +34,8 @@ abstract class HooksAbstract
 
     public const ACTION_INSERT_POST = 'wp_insert_post';
 
+    public const ACTION_USER_REGISTER = 'user_register';
+
     public const ACTION_PURGE_PLUGIN_CACHE = 'publishpressfuture_purge_plugin_cache';
 
     public const ACTION_BULK_EDIT_CUSTOM_BOX = 'bulk_edit_custom_box';

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnUserCreate.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnUserCreate.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnUserCreate implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.user-create";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onUserCreate";
+    }
+
+    public function getLabel(): string
+    {
+        return __("New user is created", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This trigger activates when a new user is created.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("User Filter", "post-expirator"),
+                "description" => __(
+                    "Specify the criteria for users whose creation will trigger this action.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User query", "post-expirator"),
+                        "description" => __(
+                            "The query defines the users whose creation will trigger this action.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                            "userRoleDescription" => __(
+                                "The trigger activates only when the new user has one of the "
+                                . "selected roles. Leave empty to trigger for any role.",
+                                "post-expirator"
+                            ),
+                        ],
+                        "default" => [
+                            "userSource" => "custom",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasOutgoingConnection",
+                    ],
+                ]
+            ]
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "user",
+                "type" => "user",
+                "label" => __("Created user", "post-expirator"),
+                "description" => __("The user that was created.", "post-expirator"),
+            ],
+            [
+                "name" => "userId",
+                "type" => "integer",
+                "label" => __("Created user's ID", "post-expirator"),
+                "description" => __("The ID of the user that was created.", "post-expirator"),
+            ],
+            [
+                "name" => "roles",
+                "type" => "array",
+                "label" => __("User roles", "post-expirator"),
+                "description" => __("The roles assigned to the user on creation.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnUserCreateRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnUserCreateRunner.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\ArrayResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\UserResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserCreate;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnUserCreateRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        ExecutionContextInterface $executionContext,
+        WorkflowExecutionSafeguardInterface $executionSafeguard
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->executionContext = $executionContext;
+        $this->executionSafeguard = $executionSafeguard;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnUserCreate::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_USER_REGISTER,
+            [$this, 'onUserRegisterCallback'],
+            20,
+            1
+        );
+    }
+
+    public function onUserRegisterCallback($userId): void
+    {
+        $userId = (int) $userId;
+
+        $user = get_userdata($userId);
+
+        if (! ($user instanceof \WP_User)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: User #%d not found for step "%s".',
+                $userId,
+                $this->stepSlug
+            );
+
+            return;
+        }
+
+        $userRoles = (array) $user->roles;
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'user' => new UserResolver($user),
+            'userId' => new IntegerResolver($userId),
+            'roles' => new ArrayResolver($userRoles),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.userId', $userId);
+
+        if (! $this->matchesRoleFilter($userRoles)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: Role conditions not met for step "%s" and user #%d (roles: %s).',
+                $this->stepSlug,
+                $userId,
+                implode(', ', $userRoles)
+            );
+
+            return;
+        }
+
+        if ($this->shouldAbortExecution($userId)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: Execution should be aborted for step "%s" and user #%d.',
+                $this->stepSlug,
+                $userId
+            );
+
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $userId
+        );
+    }
+
+    /**
+     * A user matches when no role is selected (any role) or one of its roles
+     * is in the selected list.
+     */
+    private function matchesRoleFilter(array $userRoles): bool
+    {
+        $selectedRoles = $this->getSelectedRoles();
+
+        if (empty($selectedRoles)) {
+            return true;
+        }
+
+        return count(array_intersect($selectedRoles, $userRoles)) > 0;
+    }
+
+    private function getSelectedRoles(): array
+    {
+        $settings = $this->stepProcessor->getNodeSettings($this->step['node']);
+
+        $selectedRoles = $settings['userQuery']['userRole'] ?? [];
+
+        return is_array($selectedRoles) ? array_values($selectedRoles) : [];
+    }
+
+    private function shouldAbortExecution(int $userId): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $userId,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and user #%d.',
+                $this->stepSlug,
+                $userId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $userId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for user #%d.', $this->stepSlug, $userId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/HooksAbstract.php
+++ b/src/Modules/Workflows/HooksAbstract.php
@@ -45,6 +45,8 @@ abstract class HooksAbstract
      */
     public const ACTION_SET_OBJECT_TERMS = CoreHooksAbstract::ACTION_SET_OBJECT_TERMS;
 
+    public const ACTION_USER_REGISTER = CoreHooksAbstract::ACTION_USER_REGISTER;
+
     public const ACTION_INIT = CoreHooksAbstract::ACTION_INIT;
 
     public const ACTION_ADMIN_INIT = CoreHooksAbstract::ACTION_ADMIN_INIT;

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -44,6 +44,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostWorkflowEnable;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnSchedule;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserRoleChange;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserCreate;
 use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
 
@@ -227,6 +228,7 @@ class StepTypesModel implements StepTypesModelInterface
             OnPostAuthorChange::getNodeTypeName() => new OnPostAuthorChange(),
             OnPostRowAction::getNodeTypeName() => new OnPostRowAction(),
             OnUserRoleChange::getNodeTypeName() => new OnUserRoleChange(),
+            OnUserCreate::getNodeTypeName() => new OnUserCreate(),
             OnTermsAdded::getNodeTypeName() => new OnTermsAdded(),
             OnCustomAction::getNodeTypeName() => new OnCustomAction(),
         ];


### PR DESCRIPTION
## Summary

Adds a new **Action Workflows** trigger — **"New user is created"** — that starts a workflow when a new user is registered (WordPress `user_register`).

In the Element sidebar the trigger shows a **User Filter**: select one or more roles and the workflow only runs for users created with one of those roles. Leave it empty to trigger for any role.

## What's included

- **`OnUserCreate`** definition — node `trigger/core.user-create`, `user` category, `admin-users` icon. Reuses the existing `userQuery` settings field for role selection (same field the "User role is changed" trigger uses), so **no JS rebuild is required**. Outputs `user`, `userId`, `roles`.
- **`OnUserCreateRunner`** — hooks `user_register`, resolves `user`/`userId`/`roles` into the execution context, applies the role filter, guards against duplicate execution, then runs the next steps. Modeled on `OnPostSaveRunner`.
- Registers the definition in `StepTypesModel` and the runner in `services.php`.
- Adds `ACTION_USER_REGISTER` hook constant (`Core\HooksAbstract` + `Workflows\HooksAbstract`).
- Adds bottom margin under editor token-field boxes in `workflow-editor.css` so the field description doesn't crowd the box.

## Notes

- Unlike the sibling user triggers (which are Pro-gated stubs in free), this ships as a working trigger in free — `isProFeature()` returns `false` and the runner is fully implemented. Flip `isProFeature()` to `true` + swap the runner for the stub pattern if it should be Pro-only instead.
- The `userQuery` field also renders a "User ID" input below the roles picker (part of that shared component). The runner ignores it and filters on roles only. A roles-only field would require a new JSX field-type component + build.

## Test plan

- [ ] Create a workflow with the "New user is created" trigger.
- [ ] Leave roles empty → workflow runs for any newly created user.
- [ ] Select specific roles → workflow runs only when a user is created with one of those roles.
- [ ] Verify `user` / `userId` / `roles` are available to downstream steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)