### PR TITLE
Add "User is deleted" workflow trigger

### DIFF
--- a/services.php
+++ b/services.php
@@ -115,6 +115,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostUp
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostWorkflowEnableRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnScheduleRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserRoleChangeRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserDeleteRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnTermsAddedRunner;
 use PublishPress\Future\Modules\Workflows\HooksAbstract as WorkflowsHooksAbstract;
 use PublishPress\Future\Modules\Workflows\Logger\WorkflowLogger;
@@ -1115,6 +1116,16 @@ return [
                     $stepRunner = new OnUserRoleChangeRunner(
                         $generalStepProcessor,
                         $workflowLogger
+                    );
+                    break;
+
+                case OnUserDeleteRunner::getNodeTypeName():
+                    $stepRunner = new OnUserDeleteRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $executionContext,
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD)
                     );
                     break;
 

--- a/src/Core/HooksAbstract.php
+++ b/src/Core/HooksAbstract.php
@@ -34,6 +34,8 @@ abstract class HooksAbstract
 
     public const ACTION_INSERT_POST = 'wp_insert_post';
 
+    public const ACTION_USER_DELETED = 'deleted_user';
+
     public const ACTION_PURGE_PLUGIN_CACHE = 'publishpressfuture_purge_plugin_cache';
 
     public const ACTION_BULK_EDIT_CUSTOM_BOX = 'bulk_edit_custom_box';

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnUserDelete.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnUserDelete.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnUserDelete implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.user-delete";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onUserDelete";
+    }
+
+    public function getLabel(): string
+    {
+        return __("User is deleted", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This trigger activates when a user is deleted.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("User Filter", "post-expirator"),
+                "description" => __(
+                    "Specify the criteria for users whose deletion will trigger this action.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User query", "post-expirator"),
+                        "description" => __(
+                            "The query defines the users whose deletion will trigger this action.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                            "userRoleDescription" => __(
+                                "The trigger activates only when the deleted user had one of the "
+                                . "selected roles. Leave empty to trigger for any role.",
+                                "post-expirator"
+                            ),
+                        ],
+                        "default" => [
+                            "userSource" => "custom",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasOutgoingConnection",
+                    ],
+                ]
+            ]
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "user",
+                "type" => "user",
+                "label" => __("Deleted user", "post-expirator"),
+                "description" => __("The user that was deleted.", "post-expirator"),
+            ],
+            [
+                "name" => "userId",
+                "type" => "integer",
+                "label" => __("Deleted user's ID", "post-expirator"),
+                "description" => __("The ID of the user that was deleted.", "post-expirator"),
+            ],
+            [
+                "name" => "roles",
+                "type" => "array",
+                "label" => __("User roles", "post-expirator"),
+                "description" => __("The roles the user had when deleted.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnUserDeleteRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnUserDeleteRunner.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\ArrayResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\UserResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserDelete;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnUserDeleteRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        ExecutionContextInterface $executionContext,
+        WorkflowExecutionSafeguardInterface $executionSafeguard
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->executionContext = $executionContext;
+        $this->executionSafeguard = $executionSafeguard;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnUserDelete::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_USER_DELETED,
+            [$this, 'onDeletedUserCallback'],
+            20,
+            3
+        );
+    }
+
+    /**
+     * Fires on `deleted_user`. The user record is already removed at this
+     * point, so we rely on the WP_User object WordPress passes in rather than
+     * looking it up again.
+     *
+     * @param int $userId
+     * @param int|null $reassign
+     * @param \WP_User $user
+     */
+    public function onDeletedUserCallback($userId, $reassign = null, $user = null): void
+    {
+        $userId = (int) $userId;
+
+        if (! ($user instanceof \WP_User)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: User object not available for user #%d and step "%s".',
+                $userId,
+                $this->stepSlug
+            );
+
+            return;
+        }
+
+        $userRoles = (array) $user->roles;
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'user' => new UserResolver($user),
+            'userId' => new IntegerResolver($userId),
+            'roles' => new ArrayResolver($userRoles),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.userId', $userId);
+
+        if (! $this->matchesRoleFilter($userRoles)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: Role conditions not met for step "%s" and user #%d (roles: %s).',
+                $this->stepSlug,
+                $userId,
+                implode(', ', $userRoles)
+            );
+
+            return;
+        }
+
+        if ($this->shouldAbortExecution($userId)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: Execution should be aborted for step "%s" and user #%d.',
+                $this->stepSlug,
+                $userId
+            );
+
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $userId
+        );
+    }
+
+    /**
+     * A user matches when no role is selected (any role) or one of its roles
+     * is in the selected list.
+     */
+    private function matchesRoleFilter(array $userRoles): bool
+    {
+        $selectedRoles = $this->getSelectedRoles();
+
+        if (empty($selectedRoles)) {
+            return true;
+        }
+
+        return count(array_intersect($selectedRoles, $userRoles)) > 0;
+    }
+
+    private function getSelectedRoles(): array
+    {
+        $settings = $this->stepProcessor->getNodeSettings($this->step['node']);
+
+        $selectedRoles = $settings['userQuery']['userRole'] ?? [];
+
+        return is_array($selectedRoles) ? array_values($selectedRoles) : [];
+    }
+
+    private function shouldAbortExecution(int $userId): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $userId,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and user #%d.',
+                $this->stepSlug,
+                $userId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $userId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for user #%d.', $this->stepSlug, $userId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/HooksAbstract.php
+++ b/src/Modules/Workflows/HooksAbstract.php
@@ -45,6 +45,8 @@ abstract class HooksAbstract
      */
     public const ACTION_SET_OBJECT_TERMS = CoreHooksAbstract::ACTION_SET_OBJECT_TERMS;
 
+    public const ACTION_USER_DELETED = CoreHooksAbstract::ACTION_USER_DELETED;
+
     public const ACTION_INIT = CoreHooksAbstract::ACTION_INIT;
 
     public const ACTION_ADMIN_INIT = CoreHooksAbstract::ACTION_ADMIN_INIT;

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -44,6 +44,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostWorkflowEnable;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnSchedule;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserRoleChange;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserDelete;
 use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
 
@@ -227,6 +228,7 @@ class StepTypesModel implements StepTypesModelInterface
             OnPostAuthorChange::getNodeTypeName() => new OnPostAuthorChange(),
             OnPostRowAction::getNodeTypeName() => new OnPostRowAction(),
             OnUserRoleChange::getNodeTypeName() => new OnUserRoleChange(),
+            OnUserDelete::getNodeTypeName() => new OnUserDelete(),
             OnTermsAdded::getNodeTypeName() => new OnTermsAdded(),
             OnCustomAction::getNodeTypeName() => new OnCustomAction(),
         ];


### PR DESCRIPTION
## Summary

Adds a new **Action Workflows** trigger — **"User is deleted"** — that starts a workflow when a user is deleted (WordPress `deleted_user`).

In the Element sidebar the trigger shows a **User Filter**: select one or more roles and the workflow only runs for deleted users that had one of those roles. Leave it empty to trigger for any role.

Companion to #1661 ("New user is created"), following the same structure.

## What's included

- **`OnUserDelete`** definition — node `trigger/core.user-delete`, `user` category, `admin-users` icon. Reuses the existing `userQuery` settings field for role selection, so **no JS rebuild is required**. Outputs `user`, `userId`, `roles`.
- **`OnUserDeleteRunner`** — hooks `deleted_user` and uses the `WP_User` object WordPress passes to the callback (the user record is already removed by this point, so `get_userdata()` would return nothing). Resolves `user`/`userId`/`roles` into the execution context, applies the role filter, guards against duplicate execution, then runs the next steps.
- Registers the definition in `StepTypesModel` and the runner in `services.php`.
- Adds `ACTION_USER_DELETED` hook constant (`Core\HooksAbstract` + `Workflows\HooksAbstract`).

## Notes

- Uses `deleted_user` (fires after deletion) rather than `delete_user` (before), so the workflow represents a completed deletion. Role data comes from the passed `WP_User`.
- Ships as a working trigger in free (`isProFeature()` = `false`). Flip to `true` + swap the runner for the stub pattern if it should be Pro-only.
- The `userQuery` field also renders a "User ID" input below the roles picker (shared component); the runner ignores it and filters on roles only.
- The editor token-field spacing polish is proposed separately in #1661 and intentionally not duplicated here.

## Test plan

- [ ] Create a workflow with the "User is deleted" trigger.
- [ ] Leave roles empty → workflow runs for any deleted user.
- [ ] Select specific roles → workflow runs only when a deleted user had one of those roles.
- [ ] Verify `user` / `userId` / `roles` are available to downstream steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)