### PR TITLE
Add user actions to Action Workflows (roles, meta, profile)

### DIFF
--- a/services.php
+++ b/services.php
@@ -82,6 +82,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Engine\JsonLogicEngine;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\Cron as CronStep;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\General as GeneralStep;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\Post as PostStep;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\User as UserStep;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\ChangePostStatusRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\DeactivatePostWorkflowRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\DeletePostRunner;
@@ -100,6 +101,12 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SendRayRu
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SetPostTermRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostMetaRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\ChangeUserRoleRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\AddUserRoleRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\RemoveUserRoleRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdateUserMetaRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\DeleteUserMetaRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdateUserProfileRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -877,6 +884,24 @@ return [
         };
     },
 
+    ServicesAbstract::USER_STEP_PROCESSOR_FACTORY =>
+    static function (ContainerInterface $container): \Closure {
+        return static function (
+            StepProcessorInterface $generalProcessor,
+            string $workflowExecutionId
+        ) use ($container): StepProcessorInterface {
+            $executionContext = $container->get(ServicesAbstract::EXECUTION_CONTEXT_REGISTRY)
+                ->getExecutionContext($workflowExecutionId);
+
+            return new UserStep(
+                $container->get(ServicesAbstract::HOOKS),
+                $generalProcessor,
+                $container->get(ServicesAbstract::LOGGER),
+                $executionContext
+            );
+        };
+    },
+
     ServicesAbstract::CRON_STEP_PROCESSOR_FACTORY =>
     static function (ContainerInterface $container): \Closure {
         return static function (
@@ -1224,6 +1249,86 @@ return [
                         $hooks,
                         $postStepProcessor,
                         $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $workflowLogger
+                    );
+                    break;
+
+                case ChangeUserRoleRunner::getNodeTypeName():
+                    $userStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::USER_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new ChangeUserRoleRunner(
+                        $userStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case AddUserRoleRunner::getNodeTypeName():
+                    $userStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::USER_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new AddUserRoleRunner(
+                        $userStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case RemoveUserRoleRunner::getNodeTypeName():
+                    $userStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::USER_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new RemoveUserRoleRunner(
+                        $userStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case UpdateUserMetaRunner::getNodeTypeName():
+                    $userStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::USER_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new UpdateUserMetaRunner(
+                        $userStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case DeleteUserMetaRunner::getNodeTypeName():
+                    $userStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::USER_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new DeleteUserMetaRunner(
+                        $userStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case UpdateUserProfileRunner::getNodeTypeName():
+                    $userStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::USER_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new UpdateUserProfileRunner(
+                        $userStepProcessor,
+                        $executionContext,
                         $workflowLogger
                     );
                     break;

--- a/src/Core/DI/ServicesAbstract.php
+++ b/src/Core/DI/ServicesAbstract.php
@@ -178,6 +178,8 @@ abstract class ServicesAbstract
 
     public const POST_STEP_PROCESSOR_FACTORY = 'future.free/workflows/port-step-processor-factory';
 
+    public const USER_STEP_PROCESSOR_FACTORY = 'future.free/workflows/user-step-processor-factory';
+
     /**
      * @deprecated 4.4.1 User CRON_STEP_PROCESSOR_FACTORY instead.
      */

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/AddUserRole.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/AddUserRole.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+use PublishPress\Future\Modules\Workflows\Models\UserRolesModel;
+
+class AddUserRole implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.user-add-role";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "addUserRole";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Add user role", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step adds a role to the user, keeping their existing roles.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        $userRolesModel = new UserRolesModel();
+
+        return [
+            [
+                "label" => __("Target User", "post-expirator"),
+                "description" => __("Select which user this step will act on.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User to act on", "post-expirator"),
+                        "description" => __(
+                            "Choose the user this step will act on. By default it acts on the "
+                            . "user received from the trigger.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "acceptsInput" => true,
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                        ],
+                        "default" => [
+                            "userSource" => "input",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Role", "post-expirator"),
+                "description" => __("The role to add to the user.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "role",
+                        "type" => "select",
+                        "label" => __("Role to add", "post-expirator"),
+                        "description" => __("The role to add to the user.", "post-expirator"),
+                        "settings" => [
+                            "options" => $userRolesModel->getUserRolesAsOptions(),
+                        ],
+                        "default" => "",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "role",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/ChangeUserRole.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/ChangeUserRole.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+use PublishPress\Future\Modules\Workflows\Models\UserRolesModel;
+
+class ChangeUserRole implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.user-change-role";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "changeUserRole";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Change user role", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step replaces the user's role(s) with the selected role.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        $userRolesModel = new UserRolesModel();
+
+        return [
+            [
+                "label" => __("Target User", "post-expirator"),
+                "description" => __("Select which user this step will act on.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User to act on", "post-expirator"),
+                        "description" => __(
+                            "Choose the user this step will act on. By default it acts on the "
+                            . "user received from the trigger.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "acceptsInput" => true,
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                        ],
+                        "default" => [
+                            "userSource" => "input",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Role", "post-expirator"),
+                "description" => __("The role that will replace the user's current role(s).", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "role",
+                        "type" => "select",
+                        "label" => __("New role", "post-expirator"),
+                        "description" => __("The role to assign to the user.", "post-expirator"),
+                        "settings" => [
+                            "options" => $userRolesModel->getUserRolesAsOptions(),
+                        ],
+                        "default" => "",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "role",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/DeleteUserMeta.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/DeleteUserMeta.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class DeleteUserMeta implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.user-meta-delete";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "deleteUserMeta";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Delete user meta", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step deletes a user meta value from the user.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Target User", "post-expirator"),
+                "description" => __("Select which user this step will act on.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User to act on", "post-expirator"),
+                        "description" => __(
+                            "Choose the user this step will act on. By default it acts on the "
+                            . "user received from the trigger.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "acceptsInput" => true,
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                        ],
+                        "default" => [
+                            "userSource" => "input",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Meta", "post-expirator"),
+                "description" => __("The meta to delete from the user.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "metaKey",
+                        "type" => "text",
+                        "label" => __("Meta key", "post-expirator"),
+                        "description" => __("The meta key to delete from the user.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "metaKey",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/RemoveUserRole.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/RemoveUserRole.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+use PublishPress\Future\Modules\Workflows\Models\UserRolesModel;
+
+class RemoveUserRole implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.user-remove-role";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "removeUserRole";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Remove user role", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step removes a role from the user.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        $userRolesModel = new UserRolesModel();
+
+        return [
+            [
+                "label" => __("Target User", "post-expirator"),
+                "description" => __("Select which user this step will act on.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User to act on", "post-expirator"),
+                        "description" => __(
+                            "Choose the user this step will act on. By default it acts on the "
+                            . "user received from the trigger.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "acceptsInput" => true,
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                        ],
+                        "default" => [
+                            "userSource" => "input",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Role", "post-expirator"),
+                "description" => __("The role to remove from the user.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "role",
+                        "type" => "select",
+                        "label" => __("Role to remove", "post-expirator"),
+                        "description" => __("The role to remove from the user.", "post-expirator"),
+                        "settings" => [
+                            "options" => $userRolesModel->getUserRolesAsOptions(),
+                        ],
+                        "default" => "",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "role",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/UpdateUserMeta.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/UpdateUserMeta.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class UpdateUserMeta implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.user-meta-update";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "updateUserMeta";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Update user meta", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step updates a user meta value for the user.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Target User", "post-expirator"),
+                "description" => __("Select which user this step will act on.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User to act on", "post-expirator"),
+                        "description" => __(
+                            "Choose the user this step will act on. By default it acts on the "
+                            . "user received from the trigger.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "acceptsInput" => true,
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                        ],
+                        "default" => [
+                            "userSource" => "input",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Meta", "post-expirator"),
+                "description" => __("The meta to update for the user.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "metaKey",
+                        "type" => "text",
+                        "label" => __("Meta key", "post-expirator"),
+                        "description" => __("The meta key to update for the user.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "metaValue",
+                        "type" => "expression",
+                        "label" => __("Meta value", "post-expirator"),
+                        "description" => __("The meta value to store for the user.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "metaKey",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/UpdateUserProfile.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/UpdateUserProfile.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class UpdateUserProfile implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.user-update";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "updateUserProfile";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Update user profile", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step updates profile fields for the user.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "admin-users";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "user";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Target User", "post-expirator"),
+                "description" => __("Select which user this step will act on.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userQuery",
+                        "type" => "userQuery",
+                        "label" => __("User to act on", "post-expirator"),
+                        "description" => __(
+                            "Choose the user this step will act on. By default it acts on the "
+                            . "user received from the trigger.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "acceptsInput" => true,
+                            "labels" => [
+                                "userRole" => __("User roles", "post-expirator"),
+                            ],
+                        ],
+                        "default" => [
+                            "userSource" => "input",
+                            "userRole" => [],
+                            "userId" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Profile fields", "post-expirator"),
+                "description" => __(
+                    "Only fields with a value will be updated. Leave a field empty to keep it unchanged.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "displayName",
+                        "type" => "expression",
+                        "label" => __("Display name", "post-expirator"),
+                        "description" => __("The public display name.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "firstName",
+                        "type" => "expression",
+                        "label" => __("First name", "post-expirator"),
+                    ],
+                    [
+                        "name" => "lastName",
+                        "type" => "expression",
+                        "label" => __("Last name", "post-expirator"),
+                    ],
+                    [
+                        "name" => "email",
+                        "type" => "expression",
+                        "label" => __("Email", "post-expirator"),
+                        "description" => __("The user's email address.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "url",
+                        "type" => "expression",
+                        "label" => __("Website", "post-expirator"),
+                    ],
+                    [
+                        "name" => "description",
+                        "type" => "expression",
+                        "label" => __("Biographical info", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/AddUserRoleRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/AddUserRoleRunner.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddUserRole;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class AddUserRoleRunner implements StepRunnerInterface
+{
+    use UserRoleResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return AddUserRole::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $userId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $userId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+                $role = $this->getRoleFromSettings($nodeSettings);
+
+                if ($role === '') {
+                    $this->logger->debugWithArgs('No role selected, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $user = get_userdata($userId);
+                if (! ($user instanceof \WP_User)) {
+                    $this->logger->debugWithArgs('User %1$s not found | Slug: %2$s', $userId, $nodeSlug);
+                    return;
+                }
+
+                $user->add_role($role);
+
+                $this->logger->debugWithArgs(
+                    'Role %1$s added to user | User ID: %2$s | Slug: %3$s',
+                    $role,
+                    $userId,
+                    $nodeSlug
+                );
+            },
+            $userId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/ChangeUserRoleRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/ChangeUserRoleRunner.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\ChangeUserRole;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class ChangeUserRoleRunner implements StepRunnerInterface
+{
+    use UserRoleResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return ChangeUserRole::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $userId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $userId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+                $role = $this->getRoleFromSettings($nodeSettings);
+
+                if ($role === '') {
+                    $this->logger->debugWithArgs('No role selected, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $user = get_userdata($userId);
+                if (! ($user instanceof \WP_User)) {
+                    $this->logger->debugWithArgs('User %1$s not found | Slug: %2$s', $userId, $nodeSlug);
+                    return;
+                }
+
+                $user->set_role($role);
+
+                $this->logger->debugWithArgs(
+                    'User role changed to %1$s | User ID: %2$s | Slug: %3$s',
+                    $role,
+                    $userId,
+                    $nodeSlug
+                );
+            },
+            $userId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/DeleteUserMetaRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/DeleteUserMetaRunner.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DeleteUserMeta;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class DeleteUserMetaRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return DeleteUserMeta::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $userId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $userId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $metaKey = trim((string)($nodeSettings['metaKey'] ?? ''));
+                if ($metaKey === '') {
+                    $this->logger->debugWithArgs('Meta key is empty, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                delete_user_meta($userId, $metaKey);
+
+                $this->logger->debugWithArgs(
+                    'User meta %1$s deleted | User ID: %2$s | Slug: %3$s',
+                    $metaKey,
+                    $userId,
+                    $nodeSlug
+                );
+            },
+            $userId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/RemoveUserRoleRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/RemoveUserRoleRunner.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\RemoveUserRole;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class RemoveUserRoleRunner implements StepRunnerInterface
+{
+    use UserRoleResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return RemoveUserRole::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $userId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $userId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+                $role = $this->getRoleFromSettings($nodeSettings);
+
+                if ($role === '') {
+                    $this->logger->debugWithArgs('No role selected, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $user = get_userdata($userId);
+                if (! ($user instanceof \WP_User)) {
+                    $this->logger->debugWithArgs('User %1$s not found | Slug: %2$s', $userId, $nodeSlug);
+                    return;
+                }
+
+                $user->remove_role($role);
+
+                $this->logger->debugWithArgs(
+                    'Role %1$s removed from user | User ID: %2$s | Slug: %3$s',
+                    $role,
+                    $userId,
+                    $nodeSlug
+                );
+            },
+            $userId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/UpdateUserMetaRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/UpdateUserMetaRunner.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdateUserMeta;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class UpdateUserMetaRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return UpdateUserMeta::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $userId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $userId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $metaKey = trim((string)($nodeSettings['metaKey'] ?? ''));
+                if ($metaKey === '') {
+                    $this->logger->debugWithArgs('Meta key is empty, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $metaValue = $nodeSettings['metaValue'] ?? '';
+                if (is_array($metaValue)) {
+                    $metaValue = $metaValue['expression'] ?? '';
+                }
+                $metaValue = $this->executionContext->resolveExpressionsInText((string)$metaValue);
+
+                update_user_meta($userId, $metaKey, $metaValue);
+
+                $this->logger->debugWithArgs(
+                    'User meta %1$s updated | User ID: %2$s | Slug: %3$s',
+                    $metaKey,
+                    $userId,
+                    $nodeSlug
+                );
+            },
+            $userId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/UpdateUserProfileRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/UpdateUserProfileRunner.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdateUserProfile;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class UpdateUserProfileRunner implements StepRunnerInterface
+{
+    /**
+     * Map of node-setting field name => wp_update_user() userdata key.
+     */
+    private const FIELD_MAP = [
+        'displayName' => 'display_name',
+        'firstName' => 'first_name',
+        'lastName' => 'last_name',
+        'email' => 'user_email',
+        'url' => 'user_url',
+        'description' => 'description',
+    ];
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return UpdateUserProfile::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $userId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $userId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $userData = ['ID' => $userId];
+
+                foreach (self::FIELD_MAP as $field => $userDataKey) {
+                    $value = $this->resolveFieldValue($nodeSettings[$field] ?? '');
+                    if ($value === '') {
+                        continue;
+                    }
+
+                    if ($userDataKey === 'user_email') {
+                        $value = sanitize_email($value);
+                        if ($value === '' || ! is_email($value)) {
+                            $this->logger->debugWithArgs(
+                                'Invalid email, skipping email update | Slug: %1$s',
+                                $nodeSlug
+                            );
+                            continue;
+                        }
+                    }
+
+                    $userData[$userDataKey] = $value;
+                }
+
+                if (count($userData) === 1) {
+                    $this->logger->debugWithArgs('No profile fields to update, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $result = wp_update_user($userData);
+
+                if (is_wp_error($result)) {
+                    $this->logger->errorWithArgs(
+                        'Failed to update user %1$s: %2$s | Slug: %3$s',
+                        $userId,
+                        $result->get_error_message(),
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $this->logger->debugWithArgs(
+                    'User profile updated | User ID: %1$s | Slug: %2$s',
+                    $userId,
+                    $nodeSlug
+                );
+            },
+            $userId,
+            $nodeSettings
+        );
+    }
+
+    /**
+     * @param mixed $field
+     */
+    private function resolveFieldValue($field): string
+    {
+        if (is_array($field)) {
+            $field = $field['expression'] ?? '';
+        }
+
+        return trim($this->executionContext->resolveExpressionsInText((string)$field));
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/UserRoleResolverTrait.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/UserRoleResolverTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+/**
+ * Shared helper for user-role action runners: reads the selected role from the
+ * node settings, tolerating both scalar and array-shaped `select` values.
+ */
+trait UserRoleResolverTrait
+{
+    private function getRoleFromSettings(array $nodeSettings): string
+    {
+        $role = $nodeSettings['role'] ?? '';
+
+        if (is_array($role)) {
+            $role = $role['value'] ?? ($role['role'] ?? '');
+        }
+
+        return is_string($role) ? trim($role) : '';
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Processors/User.php
+++ b/src/Modules/Workflows/Domain/Steps/Processors/User.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Processors;
+
+use PublishPress\Future\Framework\WordPress\Facade\HooksFacade;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+
+/**
+ * Step processor for user-related actions. Mirrors the Post processor: it reads
+ * the node's "Target User" field (a `userQuery` field) and resolves it into a
+ * list of user IDs, then invokes the runner callback once per user.
+ *
+ * Resolution rules for the stored `userQuery` value ({userSource, userRole, userId}):
+ *  - userSource "custom": explicit `userId` entries plus every user matching one
+ *    of the selected `userRole` roles.
+ *  - otherwise (default "input"): the user that triggered the workflow, read from
+ *    the `global.trigger.userId` execution-context variable set by the user triggers.
+ */
+class User implements StepProcessorInterface
+{
+    public const LOG_PREFIX = '[WorkflowStepsProcessorsUser:%d]: ';
+
+    /**
+     * @var HooksFacade
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $generalProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HooksFacade $hooks,
+        StepProcessorInterface $generalProcessor,
+        LoggerInterface $logger,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->generalProcessor = $generalProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+        $this->workflowId = $executionContext->getVariable('global.workflow.id');
+    }
+
+    private function getLogPrefix(): string
+    {
+        return sprintf(self::LOG_PREFIX, $this->workflowId);
+    }
+
+    public function setup(array $step, callable $setupCallback): void
+    {
+        $node = $this->getNodeFromStep($step);
+        $nodeSettings = $this->getNodeSettings($node);
+
+        $userIds = $this->resolveUserIds($nodeSettings);
+
+        if (empty($userIds)) {
+            $this->logger->debugWithArgs(
+                $this->getLogPrefix() . 'Step %s didn\'t find any users, skipping',
+                $step['node']['data']['slug']
+            );
+
+            return;
+        }
+
+        foreach ($userIds as $userId) {
+            $this->logger->debugWithArgs(
+                $this->getLogPrefix() . 'Processing user %s on step %s',
+                $userId,
+                $step['node']['data']['slug']
+            );
+
+            call_user_func($setupCallback, $userId, $nodeSettings, $step);
+        }
+
+        $this->runNextSteps($step);
+    }
+
+    /**
+     * @return int[]
+     */
+    private function resolveUserIds(array $nodeSettings): array
+    {
+        $userQuery = isset($nodeSettings['userQuery']) && is_array($nodeSettings['userQuery'])
+            ? $nodeSettings['userQuery']
+            : [];
+
+        $userSource = $userQuery['userSource'] ?? 'input';
+
+        $userIds = [];
+
+        if ($userSource === 'custom') {
+            foreach ((array)($userQuery['userId'] ?? []) as $userId) {
+                $userId = intval($userId);
+                if ($userId > 0) {
+                    $userIds[] = $userId;
+                }
+            }
+
+            $roles = array_filter((array)($userQuery['userRole'] ?? []));
+            if (! empty($roles)) {
+                $usersByRole = get_users([
+                    'role__in' => $roles,
+                    'fields' => 'ID',
+                ]);
+
+                foreach ($usersByRole as $userId) {
+                    $userIds[] = intval($userId);
+                }
+            }
+        } else {
+            $triggerUserId = intval($this->executionContext->getVariable('global.trigger.userId'));
+            if ($triggerUserId > 0) {
+                $userIds[] = $triggerUserId;
+            }
+        }
+
+        return array_values(array_unique(array_filter($userIds)));
+    }
+
+    public function runNextSteps(array $step, string $branch = 'output'): void
+    {
+        $this->generalProcessor->runNextSteps($step, $branch);
+    }
+
+    public function getNextSteps(array $step, string $branch = 'output'): array
+    {
+        return $this->generalProcessor->getNextSteps($step, $branch);
+    }
+
+    public function getNodeFromStep(array $step)
+    {
+        return $this->generalProcessor->getNodeFromStep($step);
+    }
+
+    public function getSlugFromStep(array $step)
+    {
+        return $this->generalProcessor->getSlugFromStep($step);
+    }
+
+    public function getNodeSettings(array $node)
+    {
+        return $this->generalProcessor->getNodeSettings($node);
+    }
+
+    /**
+     * @deprecated 4.10.0 Use the logger instead
+     */
+    public function logError(string $message, int $workflowId, array $step)
+    {
+        $this->logger->errorWithArgs($message);
+    }
+
+    public function triggerCallbackIsRunning(): void
+    {
+        $this->generalProcessor->triggerCallbackIsRunning();
+    }
+
+    /**
+     * @deprecated 4.10.0 Use the logger instead
+     */
+    public function prepareLogMessage(string $message, ...$args): string
+    {
+        return $this->generalProcessor->prepareLogMessage($message, ...$args);
+    }
+
+    public function executeSafelyWithErrorHandling(array $step, callable $callback, ...$args): void
+    {
+        $this->generalProcessor->executeSafelyWithErrorHandling($step, $callback, ...$args);
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -9,6 +9,12 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddPostTerm;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AppendDebugLog;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\ChangePostStatus;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\ChangeUserRole;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddUserRole;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\RemoveUserRole;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdateUserMeta;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DeleteUserMeta;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdateUserProfile;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Conditional;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DeactivatePostWorkflow;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DeletePost;
@@ -249,6 +255,12 @@ class StepTypesModel implements StepTypesModelInterface
             SetPostTerm::getNodeTypeName() => new SetPostTerm(),
             RemovePostTerm::getNodeTypeName() => new RemovePostTerm(),
             ChangePostStatus::getNodeTypeName() => new ChangePostStatus(),
+            ChangeUserRole::getNodeTypeName() => new ChangeUserRole(),
+            AddUserRole::getNodeTypeName() => new AddUserRole(),
+            RemoveUserRole::getNodeTypeName() => new RemoveUserRole(),
+            UpdateUserMeta::getNodeTypeName() => new UpdateUserMeta(),
+            DeleteUserMeta::getNodeTypeName() => new DeleteUserMeta(),
+            UpdateUserProfile::getNodeTypeName() => new UpdateUserProfile(),
             SendEmail::getNodeTypeName() => new SendEmail(),
             DeactivatePostWorkflow::getNodeTypeName() => new DeactivatePostWorkflow(),
             AddPostMeta::getNodeTypeName() => new AddPostMeta(),


### PR DESCRIPTION
## Summary

Adds six native WordPress **user actions** to the Action Workflows catalog. This completes the loop with the recently added user triggers (New user is created / User is deleted / User role changed) and mirrors the existing post-side action families (Change Status / meta Add·Update·Delete / Update Post).

Informed by a survey of AutomatorWP, FlowMattic, OttoKit and Thrive Automator — user role/meta/profile actions are the most common gap-closing capability those tools offer that Future did not yet have.

## Actions added (all working in free)

| Action | Node type | WP call |
|---|---|---|
| Change user role | `action/core.user-change-role` | `WP_User::set_role()` |
| Add user role | `action/core.user-add-role` | `WP_User::add_role()` |
| Remove user role | `action/core.user-remove-role` | `WP_User::remove_role()` |
| Update user meta | `action/core.user-meta-update` | `update_user_meta()` |
| Delete user meta | `action/core.user-meta-delete` | `delete_user_meta()` |
| Update user profile | `action/core.user-update` | `wp_update_user()` |

## How target-user resolution works

New **`Domain/Steps/Processors/User.php`** step processor, mirroring `Post.php`. It reads the node's `userQuery` field and resolves it to user IDs, then invokes the runner callback once per user:

- **input** (default): the user received from the trigger, via the `global.trigger.userId` execution-context variable the user triggers set.
- **custom**: explicit user IDs and/or every user matching the selected roles (`get_users(['role__in' => …])`).

Wired through a new `USER_STEP_PROCESSOR_FACTORY` (+ `ServicesAbstract` constant), built exactly like `POST_STEP_PROCESSOR_FACTORY`.

## Notes / decisions

- **Reuses the existing `userQuery` field** for target selection (same field the user triggers use) — no JS/build change required. That field also renders a "User ID" input; the processor honours it.
- **Role value** uses a single-role `select` (options from `UserRolesModel`), matching `set_role`/`add_role`/`remove_role` semantics — avoids needing a new multiselect field type.
- **Meta/profile values** are `expression` fields resolved via `ExecutionContext::resolveExpressionsInText()`, so they support `{{...}}` merge tags from upstream steps.
- **Update user profile** only writes fields that have a value; email is validated with `is_email()` before being applied.
- No user *model* class was introduced — runners call WP functions directly, keeping the change lean.

## Files

- New: `Processors/User.php`; 6 definitions; 6 runners + `UserRoleResolverTrait`.
- Modified: `services.php` (factory + 6 runner cases), `ServicesAbstract.php` (constant), `StepTypesModel.php` (register 6 definitions).
- 17 files, all pass `php -l`.

## Test plan

- [ ] Trigger "New user is created" → "Change user role" → confirm the new user's role is replaced.
- [ ] "Add user role" / "Remove user role" adjust roles additively without wiping others.
- [ ] "Update user meta" with a `{{...}}` expression value stores the resolved value.
- [ ] "Delete user meta" removes the key.
- [ ] "Update user profile" updates only the populated fields; invalid email is skipped.
- [ ] Target-user "custom" mode acts on all users matching a selected role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)