### PR TITLE
Add query-scoped bulk post actions (change status, delete)

### DIFF
--- a/services.php
+++ b/services.php
@@ -82,7 +82,10 @@ use PublishPress\Future\Modules\Workflows\Domain\Engine\JsonLogicEngine;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\Cron as CronStep;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\General as GeneralStep;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\Post as PostStep;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Processors\PostQuery as PostQueryStep;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\ChangePostStatusRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\BulkChangePostStatusRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\BulkDeletePostsRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\DeactivatePostWorkflowRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\DeletePostRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\StickPostRunner;
@@ -877,6 +880,24 @@ return [
         };
     },
 
+    ServicesAbstract::POST_QUERY_STEP_PROCESSOR_FACTORY =>
+    static function (ContainerInterface $container): \Closure {
+        return static function (
+            StepProcessorInterface $generalProcessor,
+            string $workflowExecutionId
+        ) use ($container): StepProcessorInterface {
+            $executionContext = $container->get(ServicesAbstract::EXECUTION_CONTEXT_REGISTRY)
+                ->getExecutionContext($workflowExecutionId);
+
+            return new PostQueryStep(
+                $container->get(ServicesAbstract::HOOKS),
+                $generalProcessor,
+                $container->get(ServicesAbstract::LOGGER),
+                $executionContext
+            );
+        };
+    },
+
     ServicesAbstract::CRON_STEP_PROCESSOR_FACTORY =>
     static function (ContainerInterface $container): \Closure {
         return static function (
@@ -1223,6 +1244,35 @@ return [
                     $stepRunner = new ChangePostStatusRunner(
                         $hooks,
                         $postStepProcessor,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $workflowLogger
+                    );
+                    break;
+
+                case BulkChangePostStatusRunner::getNodeTypeName():
+                    $postQueryStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::POST_QUERY_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new BulkChangePostStatusRunner(
+                        $hooks,
+                        $postQueryStepProcessor,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $workflowLogger
+                    );
+                    break;
+
+                case BulkDeletePostsRunner::getNodeTypeName():
+                    $postQueryStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::POST_QUERY_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new BulkDeletePostsRunner(
+                        $postQueryStepProcessor,
                         $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
                         $workflowLogger
                     );

--- a/src/Core/DI/ServicesAbstract.php
+++ b/src/Core/DI/ServicesAbstract.php
@@ -178,6 +178,8 @@ abstract class ServicesAbstract
 
     public const POST_STEP_PROCESSOR_FACTORY = 'future.free/workflows/port-step-processor-factory';
 
+    public const POST_QUERY_STEP_PROCESSOR_FACTORY = 'future.free/workflows/post-query-step-processor-factory';
+
     /**
      * @deprecated 4.4.1 User CRON_STEP_PROCESSOR_FACTORY instead.
      */

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/BulkChangePostStatus.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/BulkChangePostStatus.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class BulkChangePostStatus implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.bulk-post-change-status";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "bulkChangePostStatus";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Change status of multiple posts", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step moves every post matching the query to a different status.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "media-document";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "post";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Post Query", "post-expirator"),
+                "description" => __(
+                    "The query defines which posts will be moved to a different status.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "postQuery",
+                        "type" => "postQuery",
+                        "label" => __("Post query", "post-expirator"),
+                        "description" => __(
+                            "Every post matching this query will be updated.",
+                            "post-expirator"
+                        ),
+                        "default" => [
+                            "postSource" => "custom",
+                            "postType" => ["post"],
+                            "postId" => [],
+                            "postStatus" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("New status", "post-expirator"),
+                "description" => __("The new status the matching posts will be moved to.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "newStatus",
+                        "type" => "postStatus",
+                        "label" => __("New status", "post-expirator"),
+                        "description" => __(
+                            "The new status the matching posts will be moved to.",
+                            "post-expirator"
+                        ),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/BulkDeletePosts.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/BulkDeletePosts.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class BulkDeletePosts implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.bulk-post-delete";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "bulkDeletePosts";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Delete multiple posts", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step trashes or deletes every post matching the query.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "media-document";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "post";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Post Query", "post-expirator"),
+                "description" => __(
+                    "The query defines which posts will be trashed or deleted.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "postQuery",
+                        "type" => "postQuery",
+                        "label" => __("Post query", "post-expirator"),
+                        "description" => __(
+                            "Every post matching this query will be trashed or deleted.",
+                            "post-expirator"
+                        ),
+                        "default" => [
+                            "postSource" => "custom",
+                            "postType" => ["post"],
+                            "postId" => [],
+                            "postStatus" => [],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Deletion", "post-expirator"),
+                "description" => __("Choose whether to trash or permanently delete the posts.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "mode",
+                        "type" => "select",
+                        "label" => __("Deletion mode", "post-expirator"),
+                        "description" => __(
+                            "\"Move to trash\" can be undone. \"Delete permanently\" cannot.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "options" => [
+                                [
+                                    "value" => "trash",
+                                    "label" => __("Move to trash", "post-expirator"),
+                                ],
+                                [
+                                    "value" => "delete",
+                                    "label" => __("Delete permanently", "post-expirator"),
+                                ],
+                            ],
+                        ],
+                        "default" => "trash",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/BulkChangePostStatusRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/BulkChangePostStatusRunner.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\BulkChangePostStatus;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+
+class BulkChangePostStatusRunner implements StepRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        \Closure $expirablePostModelFactory,
+        LoggerInterface $logger
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return BulkChangePostStatus::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $postId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $postId, $nodeSettings) {
+                $this->hooks->addFilter(HooksAbstract::FILTER_IGNORE_SAVE_POST_EVENT, '__return_true', 10);
+
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $newStatus = $nodeSettings['newStatus']['status'] ?? '';
+                if ($newStatus === '') {
+                    $this->logger->debugWithArgs('No status selected, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $postModel = call_user_func($this->expirablePostModelFactory, $postId);
+
+                $oldStatus = $postModel->getPostStatus();
+
+                if ($oldStatus === $newStatus) {
+                    $this->logger->debugWithArgs(
+                        'Post status is the same, skipping | Post ID: %1$s | Slug: %2$s',
+                        $postId,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                if ('publish' === $newStatus) {
+                    $postModel->publish();
+                    $this->logger->debugWithArgs('Post published | Post ID: %1$s | Slug: %2$s', $postId, $nodeSlug);
+                } else {
+                    $postModel->setPostStatus($newStatus);
+                    $this->logger->debugWithArgs(
+                        'Post status changed from %1$s to %2$s | Post ID: %3$s | Slug: %4$s',
+                        $oldStatus,
+                        $newStatus,
+                        $postId,
+                        $nodeSlug
+                    );
+                }
+
+                $this->hooks->removeFilter(HooksAbstract::FILTER_IGNORE_SAVE_POST_EVENT, '__return_true', 10);
+            },
+            $postId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/BulkDeletePostsRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/BulkDeletePostsRunner.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\BulkDeletePosts;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class BulkDeletePostsRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        \Closure $expirablePostModelFactory,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return BulkDeletePosts::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $postId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $postId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $mode = $nodeSettings['mode'] ?? 'trash';
+                if (is_array($mode)) {
+                    $mode = $mode['value'] ?? 'trash';
+                }
+
+                $postModel = call_user_func($this->expirablePostModelFactory, $postId);
+
+                if ($mode === 'delete') {
+                    $postModel->delete(true);
+                    $this->logger->debugWithArgs(
+                        'Post permanently deleted | Post ID: %1$s | Slug: %2$s',
+                        $postId,
+                        $nodeSlug
+                    );
+                } else {
+                    $postModel->setPostStatus('trash');
+                    $this->logger->debugWithArgs(
+                        'Post moved to trash | Post ID: %1$s | Slug: %2$s',
+                        $postId,
+                        $nodeSlug
+                    );
+                }
+            },
+            $postId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Processors/PostQuery.php
+++ b/src/Modules/Workflows/Domain/Steps/Processors/PostQuery.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Processors;
+
+use PublishPress\Future\Framework\WordPress\Facade\HooksFacade;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use WP_Query;
+
+/**
+ * Step processor for self-contained bulk post actions. Unlike the Post processor
+ * (which resolves a single "post" variable coming from an upstream step), this
+ * processor reads the node's own `postQuery` field, resolves it into the full set
+ * of matching post IDs, and invokes the runner callback once per post.
+ *
+ * The `postQuery` value shape ({postSource, postType, postId, postStatus}) is the
+ * same one used by the QueryPosts node and the post triggers.
+ */
+class PostQuery implements StepProcessorInterface
+{
+    public const LOG_PREFIX = '[WorkflowStepsProcessorsPostQuery:%d]: ';
+
+    /**
+     * Hard safety ceiling on the number of posts a single bulk action will touch,
+     * so an over-broad query cannot lock up a request. Adjustable via filter.
+     */
+    public const DEFAULT_MAX_POSTS = 1000;
+
+    /**
+     * @var HooksFacade
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $generalProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HooksFacade $hooks,
+        StepProcessorInterface $generalProcessor,
+        LoggerInterface $logger,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->generalProcessor = $generalProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+        $this->workflowId = $executionContext->getVariable('global.workflow.id');
+    }
+
+    private function getLogPrefix(): string
+    {
+        return sprintf(self::LOG_PREFIX, $this->workflowId);
+    }
+
+    public function setup(array $step, callable $setupCallback): void
+    {
+        $node = $this->getNodeFromStep($step);
+        $nodeSettings = $this->getNodeSettings($node);
+
+        $postIds = $this->resolvePostIds($nodeSettings);
+
+        if (empty($postIds)) {
+            $this->logger->debugWithArgs(
+                $this->getLogPrefix() . 'Step %s didn\'t match any posts, skipping',
+                $step['node']['data']['slug']
+            );
+
+            return;
+        }
+
+        foreach ($postIds as $postId) {
+            $this->logger->debugWithArgs(
+                $this->getLogPrefix() . 'Processing post %s on step %s',
+                $postId,
+                $step['node']['data']['slug']
+            );
+
+            call_user_func($setupCallback, $postId, $nodeSettings, $step);
+        }
+
+        $this->runNextSteps($step);
+    }
+
+    /**
+     * @return int[]
+     */
+    private function resolvePostIds(array $nodeSettings): array
+    {
+        $query = isset($nodeSettings['postQuery']) && is_array($nodeSettings['postQuery'])
+            ? $nodeSettings['postQuery']
+            : [];
+
+        $postIds = [];
+
+        foreach ((array)($query['postId'] ?? []) as $postId) {
+            $postId = intval($postId);
+            if ($postId > 0) {
+                $postIds[] = $postId;
+            }
+        }
+
+        if (empty($postIds)) {
+            $postTypes = array_values(array_filter((array)($query['postType'] ?? [])));
+            if (empty($postTypes)) {
+                $postTypes = ['post'];
+            }
+
+            $postStatuses = array_values(array_filter((array)($query['postStatus'] ?? [])));
+
+            $maxPosts = (int) $this->hooks->applyFilters(
+                'publishpressfuture_bulk_action_max_posts',
+                self::DEFAULT_MAX_POSTS
+            );
+
+            $wpQuery = new WP_Query([
+                'post_type' => $postTypes,
+                'post_status' => ! empty($postStatuses) ? $postStatuses : 'any',
+                'posts_per_page' => $maxPosts > 0 ? $maxPosts : -1,
+                'fields' => 'ids',
+                'no_found_rows' => true,
+                'ignore_sticky_posts' => true,
+                'suppress_filters' => false,
+            ]);
+
+            foreach ($wpQuery->posts as $postId) {
+                $postIds[] = intval($postId);
+            }
+        }
+
+        return array_values(array_unique(array_filter($postIds)));
+    }
+
+    public function runNextSteps(array $step, string $branch = 'output'): void
+    {
+        $this->generalProcessor->runNextSteps($step, $branch);
+    }
+
+    public function getNextSteps(array $step, string $branch = 'output'): array
+    {
+        return $this->generalProcessor->getNextSteps($step, $branch);
+    }
+
+    public function getNodeFromStep(array $step)
+    {
+        return $this->generalProcessor->getNodeFromStep($step);
+    }
+
+    public function getSlugFromStep(array $step)
+    {
+        return $this->generalProcessor->getSlugFromStep($step);
+    }
+
+    public function getNodeSettings(array $node)
+    {
+        return $this->generalProcessor->getNodeSettings($node);
+    }
+
+    /**
+     * @deprecated 4.10.0 Use the logger instead
+     */
+    public function logError(string $message, int $workflowId, array $step)
+    {
+        $this->logger->errorWithArgs($message);
+    }
+
+    public function triggerCallbackIsRunning(): void
+    {
+        $this->generalProcessor->triggerCallbackIsRunning();
+    }
+
+    /**
+     * @deprecated 4.10.0 Use the logger instead
+     */
+    public function prepareLogMessage(string $message, ...$args): string
+    {
+        return $this->generalProcessor->prepareLogMessage($message, ...$args);
+    }
+
+    public function executeSafelyWithErrorHandling(array $step, callable $callback, ...$args): void
+    {
+        $this->generalProcessor->executeSafelyWithErrorHandling($step, $callback, ...$args);
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -9,6 +9,8 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddPostTerm;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AppendDebugLog;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\ChangePostStatus;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\BulkChangePostStatus;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\BulkDeletePosts;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Conditional;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DeactivatePostWorkflow;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DeletePost;
@@ -249,6 +251,8 @@ class StepTypesModel implements StepTypesModelInterface
             SetPostTerm::getNodeTypeName() => new SetPostTerm(),
             RemovePostTerm::getNodeTypeName() => new RemovePostTerm(),
             ChangePostStatus::getNodeTypeName() => new ChangePostStatus(),
+            BulkChangePostStatus::getNodeTypeName() => new BulkChangePostStatus(),
+            BulkDeletePosts::getNodeTypeName() => new BulkDeletePosts(),
             SendEmail::getNodeTypeName() => new SendEmail(),
             DeactivatePostWorkflow::getNodeTypeName() => new DeactivatePostWorkflow(),
             AddPostMeta::getNodeTypeName() => new AddPostMeta(),


### PR DESCRIPTION
## Summary

Adds two **self-contained bulk actions** to Action Workflows that operate on **every post matching an embedded query**, rather than a single post passed from an upstream step:

- **Change status of multiple posts** — `action/core.bulk-post-change-status`
- **Delete multiple posts** (trash or permanent) — `action/core.bulk-post-delete`

Equivalent to AutomatorWP's "Update multiple posts" / "Delete multiple posts". This was the top-ranked gap from the automation-tools research.

## Why self-contained (not chaining QueryPosts → action)

The existing per-post loop in the Post step processor means chaining *would* work in principle — but the only node that emits a post array, **`QueryPosts`, is Pro-gated and a no-op stub in free**, so that path yields zero posts in free. Putting query resolution inside the action's own processor makes bulk actions work in free without depending on Pro.

## How it works

New **`Domain/Steps/Processors/PostQuery.php`** step processor (sibling to `Post.php` / `User.php`): reads the node's `postQuery` field, resolves it to matching post IDs with `WP_Query`, and invokes the runner callback once per post. Wired through a new `POST_QUERY_STEP_PROCESSOR_FACTORY` (+ `ServicesAbstract` constant).

- Query resolution: explicit `postId` list if provided, otherwise `WP_Query` on `postType` + `postStatus` (defaults: `['post']`, `any`).
- **Safety ceiling**: `posts_per_page` is capped at a filterable limit (`publishpressfuture_bulk_action_max_posts`, default **1000**) so an over-broad query can't lock up a request.
- Reuses the existing `postQuery` field type (same one QueryPosts and post triggers use) → **no JS/build change**.
- Runners reuse the `ExpirablePostModel` (`setPostStatus`/`publish`/`delete`), matching the single-post `ChangePostStatus`/`DeletePost` actions.

Both ship working in free (`isProFeature() = false`).

## Notes / decisions

- **Delete mode** defaults to **trash** (undoable); "Delete permanently" is an explicit opt-in in the field.
- The 1000-post ceiling is a pragmatic guard, not true batching. For very large sites, a follow-up could page through with Action Scheduler; flagged rather than silently unbounded.
- `BulkChangePostStatus` suppresses the save-post workflow-trigger loop (`FILTER_IGNORE_SAVE_POST_EVENT`) while changing status, same as the single-post action.

## Files

- New: `Processors/PostQuery.php`; 2 definitions; 2 runners.
- Modified: `services.php` (factory + 2 cases + imports), `ServicesAbstract.php` (constant), `StepTypesModel.php` (register 2 definitions).
- 8 files, all pass `php -l`.

## Test plan

- [ ] "Change status of multiple posts" with postType=post, status=publish → all matching posts move to the chosen status.
- [ ] Restrict by explicit post IDs → only those posts change.
- [ ] "Delete multiple posts" (trash) moves matches to trash; (permanent) removes them.
- [ ] Confirm the 1000 ceiling caps a broad query; verify the filter can raise it.
- [ ] Empty/no-match query logs a skip and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)