### PR TITLE
Add WooCommerce actions (expire coupon, set product price, set stock)

### DIFF
--- a/services.php
+++ b/services.php
@@ -100,6 +100,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SendRayRu
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SetPostTermRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostMetaRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooExpireCouponRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooSetProductSalePriceRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooSetProductStockRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -1232,6 +1235,30 @@ return [
                     $stepRunner = new SendEmailRunner(
                         $generalStepProcessor,
                         $container->get(ServicesAbstract::EMAIL),
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooExpireCouponRunner::getNodeTypeName():
+                    $stepRunner = new WooExpireCouponRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooSetProductSalePriceRunner::getNodeTypeName():
+                    $stepRunner = new WooSetProductSalePriceRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooSetProductStockRunner::getNodeTypeName():
+                    $stepRunner = new WooSetProductStockRunner(
+                        $generalStepProcessor,
                         $executionContext,
                         $workflowLogger
                     );

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooExpireCoupon.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooExpireCoupon.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooExpireCoupon implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-coupon-expire";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooExpireCoupon";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Expire a coupon", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step expires a WooCommerce coupon so it can no longer be used.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Coupon", "post-expirator"),
+                "description" => __("The coupon to expire.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "coupon",
+                        "type" => "expression",
+                        "label" => __("Coupon code or ID", "post-expirator"),
+                        "description" => __(
+                            "The coupon code or ID to expire.",
+                            "post-expirator"
+                        ),
+                    ],
+                    [
+                        "name" => "expiryDate",
+                        "type" => "expression",
+                        "label" => __("Expiry date (optional)", "post-expirator"),
+                        "description" => __(
+                            "A date (YYYY-MM-DD) to set as the coupon's expiry. "
+                            . "Leave empty to expire the coupon immediately.",
+                            "post-expirator"
+                        ),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "coupon",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooSetProductSalePrice.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooSetProductSalePrice.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooSetProductSalePrice implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-product-sale-price";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooSetProductSalePrice";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Set product price", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step sets the regular and/or sale price of a WooCommerce product.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Product", "post-expirator"),
+                "description" => __("The product to update.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "product",
+                        "type" => "expression",
+                        "label" => __("Product ID or SKU", "post-expirator"),
+                        "description" => __(
+                            "The ID or SKU of the product to update.",
+                            "post-expirator"
+                        ),
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Price", "post-expirator"),
+                "description" => __(
+                    "Set the regular price, the sale price, or both. Leave a field empty to keep it unchanged. "
+                    . "Set the sale price to \"0\" to clear an existing sale.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "regularPrice",
+                        "type" => "expression",
+                        "label" => __("Regular price", "post-expirator"),
+                        "description" => __("The new regular price.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "salePrice",
+                        "type" => "expression",
+                        "label" => __("Sale price", "post-expirator"),
+                        "description" => __("The new sale price.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "product",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooSetProductStock.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooSetProductStock.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooSetProductStock implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-product-stock";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooSetProductStock";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Set product stock", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step sets the stock quantity and/or stock status of a WooCommerce product.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Product", "post-expirator"),
+                "description" => __("The product to update.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "product",
+                        "type" => "expression",
+                        "label" => __("Product ID or SKU", "post-expirator"),
+                        "description" => __(
+                            "The ID or SKU of the product to update.",
+                            "post-expirator"
+                        ),
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Stock", "post-expirator"),
+                "description" => __(
+                    "Set the stock quantity and/or the stock status. Leave the quantity empty to keep it unchanged.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "stockQuantity",
+                        "type" => "expression",
+                        "label" => __("Stock quantity", "post-expirator"),
+                        "description" => __(
+                            "The new stock quantity. Setting this enables stock management for the product.",
+                            "post-expirator"
+                        ),
+                    ],
+                    [
+                        "name" => "stockStatus",
+                        "type" => "select",
+                        "label" => __("Stock status", "post-expirator"),
+                        "description" => __("The new stock status.", "post-expirator"),
+                        "settings" => [
+                            "options" => [
+                                [
+                                    "value" => "",
+                                    "label" => __("— No change —", "post-expirator"),
+                                ],
+                                [
+                                    "value" => "instock",
+                                    "label" => __("In stock", "post-expirator"),
+                                ],
+                                [
+                                    "value" => "outofstock",
+                                    "label" => __("Out of stock", "post-expirator"),
+                                ],
+                                [
+                                    "value" => "onbackorder",
+                                    "label" => __("On backorder", "post-expirator"),
+                                ],
+                            ],
+                        ],
+                        "default" => "",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "product",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooExpireCouponRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooExpireCouponRunner.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooExpireCoupon;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+use WC_Coupon;
+
+class WooExpireCouponRunner implements StepRunnerInterface
+{
+    use WooExpressionResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooExpireCoupon::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! class_exists('WC_Coupon')) {
+                    $this->logger->debugWithArgs('WooCommerce not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $couponRef = $this->resolveExpressionField($nodeSettings, 'coupon');
+                if ($couponRef === '') {
+                    $this->logger->debugWithArgs('No coupon specified, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $coupon = new WC_Coupon($couponRef);
+                if (! $coupon->get_id()) {
+                    $this->logger->debugWithArgs(
+                        'Coupon %1$s not found | Slug: %2$s',
+                        $couponRef,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $expiryDate = $this->resolveExpressionField($nodeSettings, 'expiryDate');
+                if ($expiryDate !== '') {
+                    $timestamp = strtotime($expiryDate);
+                    if ($timestamp === false) {
+                        $this->logger->debugWithArgs(
+                            'Invalid expiry date "%1$s", skipping | Slug: %2$s',
+                            $expiryDate,
+                            $nodeSlug
+                        );
+                        return;
+                    }
+                } else {
+                    // Expire immediately: set expiry to yesterday so WooCommerce treats it as expired.
+                    $timestamp = time() - DAY_IN_SECONDS;
+                }
+
+                $coupon->set_date_expires($timestamp);
+                $coupon->save();
+
+                $this->logger->debugWithArgs(
+                    'Coupon %1$s expiry set | Coupon ID: %2$s | Slug: %3$s',
+                    $couponRef,
+                    $coupon->get_id(),
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooExpressionResolverTrait.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooExpressionResolverTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+/**
+ * Shared helper for WooCommerce action runners: reads an `expression` field from
+ * the node settings and resolves any {{...}} variables through the execution
+ * context. Requires the using class to expose an $executionContext property.
+ */
+trait WooExpressionResolverTrait
+{
+    private function resolveExpressionField(array $nodeSettings, string $fieldName): string
+    {
+        $value = $nodeSettings[$fieldName] ?? '';
+
+        if (is_array($value)) {
+            $value = $value['expression'] ?? '';
+        }
+
+        return trim($this->executionContext->resolveExpressionsInText((string)$value));
+    }
+
+    /**
+     * Resolve a product reference (numeric ID or SKU) to a product ID.
+     */
+    private function resolveProductId(string $reference): int
+    {
+        if ($reference === '') {
+            return 0;
+        }
+
+        if (ctype_digit($reference)) {
+            return (int) $reference;
+        }
+
+        if (function_exists('wc_get_product_id_by_sku')) {
+            return (int) wc_get_product_id_by_sku($reference);
+        }
+
+        return 0;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooSetProductSalePriceRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooSetProductSalePriceRunner.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooSetProductSalePrice;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class WooSetProductSalePriceRunner implements StepRunnerInterface
+{
+    use WooExpressionResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooSetProductSalePrice::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('wc_get_product')) {
+                    $this->logger->debugWithArgs('WooCommerce not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $productRef = $this->resolveExpressionField($nodeSettings, 'product');
+                $productId = $this->resolveProductId($productRef);
+
+                $product = $productId > 0 ? wc_get_product($productId) : false;
+                if (! $product) {
+                    $this->logger->debugWithArgs(
+                        'Product %1$s not found | Slug: %2$s',
+                        $productRef,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $regularPrice = $this->resolveExpressionField($nodeSettings, 'regularPrice');
+                $salePrice = $this->resolveExpressionField($nodeSettings, 'salePrice');
+
+                if ($regularPrice === '' && $salePrice === '') {
+                    $this->logger->debugWithArgs('No price provided, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                if ($regularPrice !== '') {
+                    $product->set_regular_price($regularPrice);
+                }
+
+                if ($salePrice !== '') {
+                    // A sale price of "0" (or empty) clears the sale.
+                    $product->set_sale_price($salePrice === '0' ? '' : $salePrice);
+                }
+
+                $product->save();
+
+                $this->logger->debugWithArgs(
+                    'Product price updated | Product ID: %1$s | Slug: %2$s',
+                    $product->get_id(),
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooSetProductStockRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooSetProductStockRunner.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooSetProductStock;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class WooSetProductStockRunner implements StepRunnerInterface
+{
+    use WooExpressionResolverTrait;
+
+    private const VALID_STOCK_STATUSES = ['instock', 'outofstock', 'onbackorder'];
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooSetProductStock::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('wc_get_product')) {
+                    $this->logger->debugWithArgs('WooCommerce not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $productRef = $this->resolveExpressionField($nodeSettings, 'product');
+                $productId = $this->resolveProductId($productRef);
+
+                $product = $productId > 0 ? wc_get_product($productId) : false;
+                if (! $product) {
+                    $this->logger->debugWithArgs(
+                        'Product %1$s not found | Slug: %2$s',
+                        $productRef,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $stockQuantity = $this->resolveExpressionField($nodeSettings, 'stockQuantity');
+
+                $stockStatus = $nodeSettings['stockStatus'] ?? '';
+                if (is_array($stockStatus)) {
+                    $stockStatus = $stockStatus['value'] ?? '';
+                }
+                $stockStatus = is_string($stockStatus) ? trim($stockStatus) : '';
+
+                if ($stockQuantity === '' && $stockStatus === '') {
+                    $this->logger->debugWithArgs('No stock change provided, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                if ($stockQuantity !== '') {
+                    $product->set_manage_stock(true);
+                    $product->set_stock_quantity((int) $stockQuantity);
+                }
+
+                if ($stockStatus !== '' && in_array($stockStatus, self::VALID_STOCK_STATUSES, true)) {
+                    $product->set_stock_status($stockStatus);
+                }
+
+                $product->save();
+
+                $this->logger->debugWithArgs(
+                    'Product stock updated | Product ID: %1$s | Slug: %2$s',
+                    $product->get_id(),
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -27,6 +27,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Unsti
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdatePost;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdatePostMeta;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DuplicatePost;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooExpireCoupon;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooSetProductSalePrice;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooSetProductStock;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnAdminInit;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCustomAction;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnTermsAdded;
@@ -84,7 +87,7 @@ class StepTypesModel implements StepTypesModelInterface
 
     private function getDefaultCategories()
     {
-        return [
+        $categories = [
             [
                 "name" => "post",
                 "label" => __("Post", "post-expirator"),
@@ -168,6 +171,20 @@ class StepTypesModel implements StepTypesModelInterface
 
             ]
         ];
+
+        if (class_exists('WooCommerce')) {
+            $categories[] = [
+                "name" => "woocommerce",
+                "label" => __("WooCommerce", "post-expirator"),
+                "icon" => [
+                    "src" => "cart",
+                    "background" => self::DEFAULT_ICON_BACKGROUND,
+                    "foreground" => self::DEFAULT_ICON_FOREGROUND,
+                ],
+            ];
+        }
+
+        return $categories;
     }
 
     public function convertInstancesToArray($instances, $type): array
@@ -258,6 +275,12 @@ class StepTypesModel implements StepTypesModelInterface
             SendInSiteNotification::getNodeTypeName() => new SendInSiteNotification(),
             DuplicatePost::getNodeTypeName() => new DuplicatePost(),
         ];
+
+        if (class_exists('WooCommerce')) {
+            $nodesInstances[WooExpireCoupon::getNodeTypeName()] = new WooExpireCoupon();
+            $nodesInstances[WooSetProductSalePrice::getNodeTypeName()] = new WooSetProductSalePrice();
+            $nodesInstances[WooSetProductStock::getNodeTypeName()] = new WooSetProductStock();
+        }
 
         return $nodesInstances;
     }


### PR DESCRIPTION
## Summary

Adds the first **WooCommerce-domain actions** to Action Workflows. Chosen from a survey of AutomatorWP, FlowMattic, OttoKit, Uncanny and Thrive as the WooCommerce operations that best fit Future's scheduled-change model — all buildable on **native WooCommerce core** (no paid extension):

| Action | Node type | WC API |
|---|---|---|
| Expire a coupon | `action/core.woo-coupon-expire` | `WC_Coupon::set_date_expires()` |
| Set product price | `action/core.woo-product-sale-price` | `WC_Product::set_regular_price()` / `set_sale_price()` |
| Set product stock | `action/core.woo-product-stock` | `WC_Product::set_stock_quantity()` / `set_stock_status()` |

Use cases this unlocks: "expire coupon SUMMER25 on a date", "put a product on sale then revert it (two scheduled steps)", "zero out stock / mark out-of-stock on a date".

## Design

- **CRUD objects, not raw posts.** Coupons (`shop_coupon`) and products (`product`) are post types, but the actions resolve targets via `new WC_Coupon()` / `wc_get_product()` and use the WC setters + `save()`. This fires WooCommerce's own hooks, price/stock recalculation and cache invalidation — and keeps working under **HPOS**, where orders aren't posts. Reimplementing via generic post-meta writes would silently corrupt Woo state, so these are genuinely new capabilities, not the existing post actions retargeted.
- **Explicit target fields** (coupon code/ID, product ID/SKU) as `expression` fields resolved through the execution context — so they support literal values *and* `{{...}}` variables from upstream steps. Product refs accept a numeric ID or a SKU (`wc_get_product_id_by_sku`).
- **General step processor** (same pattern as `SendEmail`) — no new processor/factory, and no dependency on other in-flight branches.
- **Woo-gated**: nodes and the new "WooCommerce" node category register only when `class_exists('WooCommerce')`; each runner guards again at runtime (logs a skip if Woo is inactive).

All ship working in free (`isProFeature() = false`).

## Notes

- "Expire a coupon" sets the expiry date to **yesterday** when no date is given (immediate invalidation), or to a supplied date.
- "Set product price": empty field = unchanged; a sale price of `0` clears the sale.
- "Set product stock": providing a quantity enables `manage_stock`; stock status has a "— No change —" option.
- The existing `WooCommerce` module was a stylesheet-only stub — this is the first real Woo automation in the plugin.

## Files

- New: 3 definitions, 3 runners, `WooExpressionResolverTrait`.
- Modified: `services.php` (3 cases + imports), `StepTypesModel.php` (conditional registration + category).
- 9 files, all pass `php -l`.

## Test plan

- [ ] With WooCommerce active, the three actions + a "WooCommerce" category appear in the editor; with it inactive, they do not.
- [ ] Expire a coupon by code and by ID → coupon becomes invalid at checkout.
- [ ] Set product regular/sale price by ID and by SKU; sale price `0` clears the sale.
- [ ] Set stock quantity (enables management) and stock status.
- [ ] Runner logs a skip if WooCommerce is deactivated after a workflow was built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)