### PR TITLE
Add WooCommerce order actions (change status, add note)

### DIFF
--- a/services.php
+++ b/services.php
@@ -103,6 +103,8 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePos
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooExpireCouponRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooSetProductSalePriceRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooSetProductStockRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooChangeOrderStatusRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooAddOrderNoteRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -1258,6 +1260,22 @@ return [
 
                 case WooSetProductStockRunner::getNodeTypeName():
                     $stepRunner = new WooSetProductStockRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooChangeOrderStatusRunner::getNodeTypeName():
+                    $stepRunner = new WooChangeOrderStatusRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooAddOrderNoteRunner::getNodeTypeName():
+                    $stepRunner = new WooAddOrderNoteRunner(
                         $generalStepProcessor,
                         $executionContext,
                         $workflowLogger

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooAddOrderNote.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooAddOrderNote.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooAddOrderNote implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-order-add-note";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooAddOrderNote";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Add order note", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step adds a note to a WooCommerce order.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Order", "post-expirator"),
+                "description" => __("The order to add a note to.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "orderId",
+                        "type" => "expression",
+                        "label" => __("Order ID", "post-expirator"),
+                        "description" => __("The ID of the order to add a note to.", "post-expirator"),
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Note", "post-expirator"),
+                "description" => __("The note to add to the order.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "note",
+                        "type" => "expression",
+                        "label" => __("Note", "post-expirator"),
+                        "description" => __("The note content.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "noteType",
+                        "type" => "select",
+                        "label" => __("Note type", "post-expirator"),
+                        "description" => __(
+                            "A private note is visible to admins only. A note to the customer is emailed to them.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "options" => [
+                                [
+                                    "value" => "private",
+                                    "label" => __("Private note", "post-expirator"),
+                                ],
+                                [
+                                    "value" => "customer",
+                                    "label" => __("Note to customer", "post-expirator"),
+                                ],
+                            ],
+                        ],
+                        "default" => "private",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "orderId",
+                    ],
+                    [
+                        "rule" => "required",
+                        "field" => "note",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooChangeOrderStatus.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooChangeOrderStatus.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooChangeOrderStatus implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-order-change-status";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooChangeOrderStatus";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Change order status", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step changes the status of a specific order, or of every order matching a filter "
+            . "(for example, cancel unpaid orders older than N days).",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function getOrderStatusOptions(bool $withAny = false): array
+    {
+        $options = [];
+
+        if ($withAny) {
+            $options[] = ["value" => "any", "label" => __("Any status", "post-expirator")];
+        }
+
+        if (function_exists('wc_get_order_statuses')) {
+            foreach (wc_get_order_statuses() as $key => $label) {
+                // wc_get_order_statuses() keys are prefixed with "wc-"; the CRUD/update
+                // API expects the unprefixed slug.
+                $options[] = [
+                    "value" => (strpos($key, 'wc-') === 0) ? substr($key, 3) : $key,
+                    "label" => $label,
+                ];
+            }
+        }
+
+        return $options;
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Order selection", "post-expirator"),
+                "description" => __(
+                    "Target a specific order by ID, or leave the ID empty and use the filter to target "
+                    . "every matching order.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "orderId",
+                        "type" => "expression",
+                        "label" => __("Order ID (optional)", "post-expirator"),
+                        "description" => __(
+                            "A specific order ID. Leave empty to use the filter below.",
+                            "post-expirator"
+                        ),
+                    ],
+                    [
+                        "name" => "matchStatus",
+                        "type" => "select",
+                        "label" => __("Only orders currently in status", "post-expirator"),
+                        "description" => __("Restrict the filter to orders in this status.", "post-expirator"),
+                        "settings" => [
+                            "options" => $this->getOrderStatusOptions(true),
+                        ],
+                        "default" => "any",
+                    ],
+                    [
+                        "name" => "olderThanDays",
+                        "type" => "expression",
+                        "label" => __("Only orders older than (days)", "post-expirator"),
+                        "description" => __(
+                            "Restrict the filter to orders created more than this many days ago. "
+                            . "Leave empty for no age restriction.",
+                            "post-expirator"
+                        ),
+                    ],
+                ],
+            ],
+            [
+                "label" => __("New status", "post-expirator"),
+                "description" => __("The status the matching orders will be moved to.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "newStatus",
+                        "type" => "select",
+                        "label" => __("New status", "post-expirator"),
+                        "description" => __("The new order status.", "post-expirator"),
+                        "settings" => [
+                            "options" => $this->getOrderStatusOptions(false),
+                        ],
+                        "default" => "",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    [
+                        "rule" => "hasIncomingConnection",
+                    ],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    [
+                        "rule" => "required",
+                        "field" => "newStatus",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [
+                [
+                    "id" => "input",
+                ]
+            ],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooAddOrderNoteRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooAddOrderNoteRunner.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooAddOrderNote;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class WooAddOrderNoteRunner implements StepRunnerInterface
+{
+    use WooExpressionResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooAddOrderNote::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('wc_get_order')) {
+                    $this->logger->debugWithArgs('WooCommerce not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $orderRef = $this->resolveExpressionField($nodeSettings, 'orderId');
+                if ($orderRef === '' || ! ctype_digit($orderRef)) {
+                    $this->logger->debugWithArgs('No valid order ID, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $order = wc_get_order((int) $orderRef);
+                if (! $order) {
+                    $this->logger->debugWithArgs('Order %1$s not found | Slug: %2$s', $orderRef, $nodeSlug);
+                    return;
+                }
+
+                $note = $this->resolveExpressionField($nodeSettings, 'note');
+                if ($note === '') {
+                    $this->logger->debugWithArgs('Note is empty, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $noteType = $nodeSettings['noteType'] ?? 'private';
+                if (is_array($noteType)) {
+                    $noteType = $noteType['value'] ?? 'private';
+                }
+                $isCustomerNote = ($noteType === 'customer') ? 1 : 0;
+
+                $order->add_order_note($note, $isCustomerNote, false);
+
+                $this->logger->debugWithArgs(
+                    'Note added to order %1$s | Slug: %2$s',
+                    $orderRef,
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooChangeOrderStatusRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooChangeOrderStatusRunner.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooChangeOrderStatus;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class WooChangeOrderStatusRunner implements StepRunnerInterface
+{
+    use WooExpressionResolverTrait;
+
+    /**
+     * Filterable ceiling on how many orders a single filter-based run will touch.
+     */
+    public const DEFAULT_MAX_ORDERS = 1000;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooChangeOrderStatus::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('wc_get_order')) {
+                    $this->logger->debugWithArgs('WooCommerce not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $newStatus = $nodeSettings['newStatus'] ?? '';
+                if (is_array($newStatus)) {
+                    $newStatus = $newStatus['value'] ?? '';
+                }
+                $newStatus = is_string($newStatus) ? trim($newStatus) : '';
+
+                if ($newStatus === '') {
+                    $this->logger->debugWithArgs('No new status selected, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $orderIds = $this->resolveOrderIds($nodeSettings, $nodeSlug);
+                if (empty($orderIds)) {
+                    $this->logger->debugWithArgs('No matching orders, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                foreach ($orderIds as $orderId) {
+                    $order = wc_get_order($orderId);
+                    if (! $order) {
+                        continue;
+                    }
+
+                    if ($order->get_status() === $newStatus) {
+                        continue;
+                    }
+
+                    $order->update_status($newStatus, '', true);
+
+                    $this->logger->debugWithArgs(
+                        'Order %1$s moved to status %2$s | Slug: %3$s',
+                        $orderId,
+                        $newStatus,
+                        $nodeSlug
+                    );
+                }
+            }
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function resolveOrderIds(array $nodeSettings, string $nodeSlug): array
+    {
+        $orderId = $this->resolveExpressionField($nodeSettings, 'orderId');
+        if ($orderId !== '' && ctype_digit($orderId)) {
+            return [(int) $orderId];
+        }
+
+        if (! function_exists('wc_get_orders')) {
+            return [];
+        }
+
+        $matchStatus = $nodeSettings['matchStatus'] ?? 'any';
+        if (is_array($matchStatus)) {
+            $matchStatus = $matchStatus['value'] ?? 'any';
+        }
+
+        $maxOrders = (int) apply_filters('publishpressfuture_bulk_order_limit', self::DEFAULT_MAX_ORDERS);
+
+        $args = [
+            'return' => 'ids',
+            'limit' => $maxOrders > 0 ? $maxOrders : -1,
+        ];
+
+        if (is_string($matchStatus) && $matchStatus !== '' && $matchStatus !== 'any') {
+            $args['status'] = $matchStatus;
+        }
+
+        $olderThanDays = $this->resolveExpressionField($nodeSettings, 'olderThanDays');
+        if ($olderThanDays !== '' && is_numeric($olderThanDays) && (int) $olderThanDays > 0) {
+            $args['date_created'] = '<' . (time() - ((int) $olderThanDays * DAY_IN_SECONDS));
+        }
+
+        $ids = wc_get_orders($args);
+
+        return array_map('intval', is_array($ids) ? $ids : []);
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -30,6 +30,8 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Dupli
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooExpireCoupon;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooSetProductSalePrice;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooSetProductStock;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooChangeOrderStatus;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooAddOrderNote;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnAdminInit;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCustomAction;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnTermsAdded;
@@ -280,6 +282,8 @@ class StepTypesModel implements StepTypesModelInterface
             $nodesInstances[WooExpireCoupon::getNodeTypeName()] = new WooExpireCoupon();
             $nodesInstances[WooSetProductSalePrice::getNodeTypeName()] = new WooSetProductSalePrice();
             $nodesInstances[WooSetProductStock::getNodeTypeName()] = new WooSetProductStock();
+            $nodesInstances[WooChangeOrderStatus::getNodeTypeName()] = new WooChangeOrderStatus();
+            $nodesInstances[WooAddOrderNote::getNodeTypeName()] = new WooAddOrderNote();
         }
 
         return $nodesInstances;


### PR DESCRIPTION
## Summary

Adds two WooCommerce **order-domain** actions to Action Workflows:

| Action | Node type | WC API |
|---|---|---|
| Change order status | `action/core.woo-order-change-status` | `wc_get_orders()` + `WC_Order::update_status()` |
| Add order note | `action/core.woo-order-add-note` | `WC_Order::add_order_note()` |

**Change order status** is query-capable: target a specific order by ID, *or* leave the ID empty and target **every order matching a status + "older than N days" filter** — i.e. the flagship "auto-cancel unpaid orders after N days" use case.

> **Stacked on #1666** (WooCommerce actions). Base this PR on that branch; merge #1666 first. Both order actions register inside the same `class_exists('WooCommerce')` block and reuse the shared `WooExpressionResolverTrait` and `woocommerce` node category introduced there.

## HPOS-correct by design

Orders are resolved with `wc_get_order()` / `wc_get_orders()`, **not** post queries. Under High-Performance Order Storage, orders live in custom tables and are not posts, so a post-query approach would find nothing. Going through the WooCommerce order APIs works on both storage backends and fires Woo's own status-transition side effects (emails, stock, totals).

## Details

- **Order status options** are pulled live from `wc_get_order_statuses()` (unprefixed slugs for the CRUD API), so custom statuses appear automatically.
- Filter run is bounded by a filterable ceiling `publishpressfuture_bulk_order_limit` (default **1000**).
- `update_status()` is skipped when the order is already in the target status.
- Add order note supports **private** (admin-only) or **customer** (emailed) notes.
- Woo-gated (registration + runtime `function_exists` guard); both ship working in free.

## Files

- New: 2 definitions, 2 runners.
- Modified: `services.php` (2 cases + imports), `StepTypesModel.php` (2 registrations + imports).
- 6 files, all pass `php -l`.

## Test plan

- [ ] Change a specific order (by ID) to a new status.
- [ ] Filter run: "orders in 'pending' older than 7 days → cancelled" affects only matching orders.
- [ ] Custom order statuses appear in the dropdowns.
- [ ] Add a private note and a customer note; confirm the customer note is emailed.
- [ ] Verify correct behavior with HPOS enabled.
- [ ] Confirm the filter ceiling caps a broad run and the filter can raise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)