### PR TITLE
Add WooCommerce Subscriptions & Memberships actions (Pro)

### DIFF
--- a/services.php
+++ b/services.php
@@ -109,6 +109,10 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooCreate
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooGenerateCouponRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooCreateProductRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooCreateOrderRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooCancelSubscriptionRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooChangeSubscriptionStatusRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooAddMembershipRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\WooRemoveMembershipRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -1315,6 +1319,34 @@ return [
                     $stepRunner = new WooCreateOrderRunner(
                         $generalStepProcessor,
                         $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooCancelSubscriptionRunner::getNodeTypeName():
+                    $stepRunner = new WooCancelSubscriptionRunner(
+                        $generalStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooChangeSubscriptionStatusRunner::getNodeTypeName():
+                    $stepRunner = new WooChangeSubscriptionStatusRunner(
+                        $generalStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooAddMembershipRunner::getNodeTypeName():
+                    $stepRunner = new WooAddMembershipRunner(
+                        $generalStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case WooRemoveMembershipRunner::getNodeTypeName():
+                    $stepRunner = new WooRemoveMembershipRunner(
+                        $generalStepProcessor,
                         $workflowLogger
                     );
                     break;

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooAddMembership.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooAddMembership.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooAddMembership implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-membership-add";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooAddMembership";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Add user to a membership", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step adds a user to a WooCommerce membership plan.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Membership", "post-expirator"),
+                "description" => __("The user and membership plan.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userId",
+                        "type" => "expression",
+                        "label" => __("User ID", "post-expirator"),
+                        "description" => __("The user to add to the plan.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "planId",
+                        "type" => "expression",
+                        "label" => __("Membership plan ID", "post-expirator"),
+                        "description" => __("The membership plan to add the user to.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "userId"],
+                    ["rule" => "required", "field" => "planId"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return true;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooCancelSubscription.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooCancelSubscription.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooCancelSubscription implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-subscription-cancel";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooCancelSubscription";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Cancel a subscription", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step cancels a WooCommerce subscription.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Subscription", "post-expirator"),
+                "description" => __("The subscription to cancel.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "subscriptionId",
+                        "type" => "expression",
+                        "label" => __("Subscription ID", "post-expirator"),
+                        "description" => __("The ID of the subscription to cancel.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "subscriptionId"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return true;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooChangeSubscriptionStatus.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooChangeSubscriptionStatus.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooChangeSubscriptionStatus implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-subscription-change-status";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooChangeSubscriptionStatus";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Change subscription status", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step changes the status of a WooCommerce subscription (for example, put it on hold or reactivate it).",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Subscription", "post-expirator"),
+                "description" => __("The subscription to update.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "subscriptionId",
+                        "type" => "expression",
+                        "label" => __("Subscription ID", "post-expirator"),
+                        "description" => __("The ID of the subscription to update.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "newStatus",
+                        "type" => "select",
+                        "label" => __("New status", "post-expirator"),
+                        "settings" => [
+                            "options" => [
+                                ["value" => "active", "label" => __("Active", "post-expirator")],
+                                ["value" => "on-hold", "label" => __("On hold", "post-expirator")],
+                                ["value" => "cancelled", "label" => __("Cancelled", "post-expirator")],
+                                ["value" => "pending-cancel", "label" => __("Pending cancellation", "post-expirator")],
+                                ["value" => "expired", "label" => __("Expired", "post-expirator")],
+                            ],
+                        ],
+                        "default" => "on-hold",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "subscriptionId"],
+                    ["rule" => "required", "field" => "newStatus"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return true;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooRemoveMembership.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/WooRemoveMembership.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class WooRemoveMembership implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.woo-membership-remove";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "wooRemoveMembership";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Remove user from a membership", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step removes a user from a WooCommerce membership plan.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Membership", "post-expirator"),
+                "description" => __("The user and membership plan.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "userId",
+                        "type" => "expression",
+                        "label" => __("User ID", "post-expirator"),
+                        "description" => __("The user to remove from the plan.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "planId",
+                        "type" => "expression",
+                        "label" => __("Membership plan ID", "post-expirator"),
+                        "description" => __("The membership plan to remove the user from.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "userId"],
+                    ["rule" => "required", "field" => "planId"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return true;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooAddMembershipRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooAddMembershipRunner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooAddMembership;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+/**
+ * Pro feature. The functional implementation lives in the Pro plugin; in the
+ * free plugin this runner is a no-op that logs a skip.
+ */
+class WooAddMembershipRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooAddMembership::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $this->logger->debugWithArgs('Step %1$s is a Pro feature, skipping', $nodeSlug);
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooCancelSubscriptionRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooCancelSubscriptionRunner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooCancelSubscription;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+/**
+ * Pro feature. The functional implementation lives in the Pro plugin; in the
+ * free plugin this runner is a no-op that logs a skip.
+ */
+class WooCancelSubscriptionRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooCancelSubscription::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $this->logger->debugWithArgs('Step %1$s is a Pro feature, skipping', $nodeSlug);
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooChangeSubscriptionStatusRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooChangeSubscriptionStatusRunner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooChangeSubscriptionStatus;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+/**
+ * Pro feature. The functional implementation lives in the Pro plugin; in the
+ * free plugin this runner is a no-op that logs a skip.
+ */
+class WooChangeSubscriptionStatusRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooChangeSubscriptionStatus::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $this->logger->debugWithArgs('Step %1$s is a Pro feature, skipping', $nodeSlug);
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooRemoveMembershipRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/WooRemoveMembershipRunner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooRemoveMembership;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+/**
+ * Pro feature. The functional implementation lives in the Pro plugin; in the
+ * free plugin this runner is a no-op that logs a skip.
+ */
+class WooRemoveMembershipRunner implements StepRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return WooRemoveMembership::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $this->logger->debugWithArgs('Step %1$s is a Pro feature, skipping', $nodeSlug);
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -36,6 +36,10 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooCr
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooGenerateCoupon;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooCreateProduct;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooCreateOrder;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooCancelSubscription;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooChangeSubscriptionStatus;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooAddMembership;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\WooRemoveMembership;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnAdminInit;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCustomAction;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnTermsAdded;
@@ -292,6 +296,18 @@ class StepTypesModel implements StepTypesModelInterface
             $nodesInstances[WooGenerateCoupon::getNodeTypeName()] = new WooGenerateCoupon();
             $nodesInstances[WooCreateProduct::getNodeTypeName()] = new WooCreateProduct();
             $nodesInstances[WooCreateOrder::getNodeTypeName()] = new WooCreateOrder();
+
+            // Subscriptions actions (Pro) — only when WooCommerce Subscriptions is active.
+            if (class_exists('WC_Subscriptions')) {
+                $nodesInstances[WooCancelSubscription::getNodeTypeName()] = new WooCancelSubscription();
+                $nodesInstances[WooChangeSubscriptionStatus::getNodeTypeName()] = new WooChangeSubscriptionStatus();
+            }
+
+            // Memberships actions (Pro) — only when WooCommerce Memberships is active.
+            if (function_exists('wc_memberships')) {
+                $nodesInstances[WooAddMembership::getNodeTypeName()] = new WooAddMembership();
+                $nodesInstances[WooRemoveMembership::getNodeTypeName()] = new WooRemoveMembership();
+            }
         }
 
         return $nodesInstances;


### PR DESCRIPTION
## Summary

Adds four **Pro-gated** WooCommerce extension actions — the subscription/membership operations that require paid WooCommerce extensions. Following the plugin's Pro-teaser convention: the definitions register (shown with a **Pro** badge) but their runners are **no-op stubs** in free; the functional implementation belongs in the Pro plugin.

| Action | Node type | Extension |
|---|---|---|
| Cancel a subscription | `action/core.woo-subscription-cancel` | WooCommerce Subscriptions |
| Change subscription status | `action/core.woo-subscription-change-status` | WooCommerce Subscriptions |
| Add user to a membership | `action/core.woo-membership-add` | WooCommerce Memberships |
| Remove user from a membership | `action/core.woo-membership-remove` | WooCommerce Memberships |

> **Stacked on #1668 → #1667 → #1666.** Merge those first. Reuses the shared `woocommerce` category and the `class_exists('WooCommerce')` block.

## Design

- **`isProFeature()` = true** for all four → Pro badge in the editor; runners are stubs that log `"…is a Pro feature, skipping"` (same pattern as `UpdatePostMeta`, the user triggers, etc.). The real logic ships in the Pro plugin.
- **Extension-gated registration** (nested inside the existing WooCommerce block):
  - Subscription actions register only when `class_exists('WC_Subscriptions')`.
  - Membership actions register only when `function_exists('wc_memberships')`.
  So they never appear on sites without the relevant extension.
- Definitions carry the fields the Pro runner will use (subscription ID / status; user ID + plan ID) so the editor UI is complete.

## Why stubs and not functional in free

Unlike the coupon/product/order actions (native WooCommerce core), these depend on **paid extensions** (WooCommerce Subscriptions / Memberships). Competitors Pro-gate them too. Matching this plugin's free/Pro split keeps the free tier free of paid-extension coupling while surfacing the capability as an upgrade path.

## Files

- New: 4 definitions, 4 stub runners.
- Modified: `services.php` (4 cases + imports), `StepTypesModel.php` (extension-gated registration + imports).
- 10 files, all pass `php -l`.

## Test plan

- [ ] With WooCommerce Subscriptions active, the two subscription actions appear with a Pro badge; without it, they don't.
- [ ] With WooCommerce Memberships active, the two membership actions appear with a Pro badge; without it, they don't.
- [ ] In free, running any of them logs the "Pro feature, skipping" message and does nothing.
- [ ] The Pro plugin overrides the runners with functional implementations (verified in the Pro repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)