### PR TITLE
Add PublishPress Authors integration (actions, trigger, variables)

### DIFF
--- a/services.php
+++ b/services.php
@@ -100,6 +100,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SendRayRu
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SetPostTermRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostMetaRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SetPostAuthorsRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\AddPostAuthorRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\RemovePostAuthorRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -115,6 +118,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostUp
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostWorkflowEnableRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnScheduleRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserRoleChangeRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostAuthorsChangedRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnTermsAddedRunner;
 use PublishPress\Future\Modules\Workflows\HooksAbstract as WorkflowsHooksAbstract;
 use PublishPress\Future\Modules\Workflows\Logger\WorkflowLogger;
@@ -1118,6 +1122,17 @@ return [
                     );
                     break;
 
+                case OnPostAuthorsChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnPostAuthorsChangedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
+                    );
+                    break;
+
                 case OnCustomActionRunner::getNodeTypeName():
                     $stepRunner = new OnCustomActionRunner(
                         $generalStepProcessor,
@@ -1224,6 +1239,48 @@ return [
                         $hooks,
                         $postStepProcessor,
                         $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $workflowLogger
+                    );
+                    break;
+
+                case SetPostAuthorsRunner::getNodeTypeName():
+                    $postStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::POST_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new SetPostAuthorsRunner(
+                        $postStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case AddPostAuthorRunner::getNodeTypeName():
+                    $postStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::POST_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new AddPostAuthorRunner(
+                        $postStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case RemovePostAuthorRunner::getNodeTypeName():
+                    $postStepProcessor = call_user_func(
+                        $container->get(ServicesAbstract::POST_STEP_PROCESSOR_FACTORY),
+                        $generalStepProcessor,
+                        $workflowExecutionId
+                    );
+
+                    $stepRunner = new RemovePostAuthorRunner(
+                        $postStepProcessor,
+                        $executionContext,
                         $workflowLogger
                     );
                     break;

--- a/src/Modules/Workflows/Domain/Engine/VariableResolvers/PostResolver.php
+++ b/src/Modules/Workflows/Domain/Engine/VariableResolvers/PostResolver.php
@@ -128,9 +128,38 @@ class PostResolver implements VariableResolverInterface
 
             case 'future':
                 return new FutureActionResolver($this->post, $this->expirablePostModelFactory);
+
+            case 'ppma_authors':
+                return new ArrayResolver($this->getPpmaAuthorProperty('display_name'));
+
+            case 'ppma_author_emails':
+                return new ArrayResolver($this->getPpmaAuthorProperty('user_email'));
         }
 
         return '';
+    }
+
+    /**
+     * Read a property from every PublishPress Authors author assigned to the post.
+     * Returns an empty array when PublishPress Authors is not active.
+     *
+     * @return array
+     */
+    private function getPpmaAuthorProperty(string $property): array
+    {
+        if (! function_exists('get_post_authors')) {
+            return [];
+        }
+
+        $values = [];
+        foreach (get_post_authors($this->post->ID) as $author) {
+            $value = isset($author->$property) ? (string) $author->$property : '';
+            if ($value !== '') {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
     }
 
     public function getValueAsString(string $property = ''): string
@@ -202,6 +231,8 @@ class PostResolver implements VariableResolverInterface
                 'author',
                 'terms',
                 'future',
+                'ppma_authors',
+                'ppma_author_emails',
             ]
         );
     }

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/AddPostAuthor.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/AddPostAuthor.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class AddPostAuthor implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.add-post-author";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "addPostAuthor";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Add post author", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step adds one or more co-authors to a post, keeping its existing authors.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "groups";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "authors";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Target Post", "post-expirator"),
+                "description" => __("Select which post will have authors added.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "post",
+                        "type" => "postInput",
+                        "label" => __("Post", "post-expirator"),
+                        "description" => __("The post to add authors to.", "post-expirator"),
+                        "default" => [
+                            "variable" => [
+                                "rule" => "first",
+                                "dataType" => "post",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Authors", "post-expirator"),
+                "description" => __(
+                    "The authors to add, as a comma-separated list of author slugs, emails, or IDs. "
+                    . "Existing authors are kept.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "authors",
+                        "type" => "expression",
+                        "label" => __("Authors to add", "post-expirator"),
+                        "description" => __("Comma-separated author slugs, emails, or term IDs.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "post.variable"],
+                    ["rule" => "required", "field" => "authors"],
+                    [
+                        "rule" => "validVariable",
+                        "field" => "post.variable",
+                        "fieldLabel" => __("Post", "post-expirator"),
+                        "dataType" => ["post", "array:integer"],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/RemovePostAuthor.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/RemovePostAuthor.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class RemovePostAuthor implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.remove-post-author";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "removePostAuthor";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Remove post author", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step removes one or more authors from a post, keeping the rest.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "groups";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "authors";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Target Post", "post-expirator"),
+                "description" => __("Select which post will have authors removed.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "post",
+                        "type" => "postInput",
+                        "label" => __("Post", "post-expirator"),
+                        "description" => __("The post to remove authors from.", "post-expirator"),
+                        "default" => [
+                            "variable" => [
+                                "rule" => "first",
+                                "dataType" => "post",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Authors", "post-expirator"),
+                "description" => __(
+                    "The authors to remove, as a comma-separated list of author slugs, emails, or IDs.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "authors",
+                        "type" => "expression",
+                        "label" => __("Authors to remove", "post-expirator"),
+                        "description" => __("Comma-separated author slugs, emails, or term IDs.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "post.variable"],
+                    ["rule" => "required", "field" => "authors"],
+                    [
+                        "rule" => "validVariable",
+                        "field" => "post.variable",
+                        "fieldLabel" => __("Post", "post-expirator"),
+                        "dataType" => ["post", "array:integer"],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/SetPostAuthors.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/SetPostAuthors.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class SetPostAuthors implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.set-post-authors";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "setPostAuthors";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Set post authors", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This step replaces a post's PublishPress Authors with the specified authors.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "groups";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "authors";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Target Post", "post-expirator"),
+                "description" => __("Select which post will have its authors set.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "post",
+                        "type" => "postInput",
+                        "label" => __("Post", "post-expirator"),
+                        "description" => __("The post whose authors will be set.", "post-expirator"),
+                        "default" => [
+                            "variable" => [
+                                "rule" => "first",
+                                "dataType" => "post",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "label" => __("Authors", "post-expirator"),
+                "description" => __(
+                    "The authors to assign, as a comma-separated list of author slugs, emails, or IDs. "
+                    . "This replaces the post's existing authors.",
+                    "post-expirator"
+                ),
+                "fields" => [
+                    [
+                        "name" => "authors",
+                        "type" => "expression",
+                        "label" => __("Authors", "post-expirator"),
+                        "description" => __("Comma-separated author slugs, emails, or term IDs.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "post.variable"],
+                    ["rule" => "required", "field" => "authors"],
+                    [
+                        "rule" => "validVariable",
+                        "field" => "post.variable",
+                        "fieldLabel" => __("Post", "post-expirator"),
+                        "dataType" => ["post", "array:integer"],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/AddPostAuthorRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/AddPostAuthorRunner.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use MultipleAuthors\Classes\Utils;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddPostAuthor;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class AddPostAuthorRunner implements StepRunnerInterface
+{
+    use AuthorsResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return AddPostAuthor::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $postId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $postId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! class_exists(Utils::class) || ! function_exists('get_post_authors')) {
+                    $this->logger->debugWithArgs('PublishPress Authors not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $toAdd = $this->resolveAuthors($this->resolveExpressionField($nodeSettings, 'authors'));
+                if (empty($toAdd)) {
+                    $this->logger->debugWithArgs('No authors resolved, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                // Merge with existing authors, de-duplicated by term ID.
+                $merged = [];
+                foreach (get_post_authors($postId) as $author) {
+                    if (! empty($author->term_id)) {
+                        $merged[(int) $author->term_id] = $author;
+                    }
+                }
+                foreach ($toAdd as $author) {
+                    $merged[(int) $author->term_id] = $author;
+                }
+
+                Utils::set_post_authors($postId, array_values($merged));
+
+                $this->logger->debugWithArgs(
+                    'Added %1$d author(s) to post | Post ID: %2$s | Slug: %3$s',
+                    count($toAdd),
+                    $postId,
+                    $nodeSlug
+                );
+            },
+            $postId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/AuthorsResolverTrait.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/AuthorsResolverTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use MultipleAuthors\Classes\Objects\Author;
+
+/**
+ * Shared helpers for PublishPress Authors action runners: resolves a
+ * comma-separated list of author references (term ID, slug, or email) into
+ * Author objects, tolerating expression/scalar field storage.
+ */
+trait AuthorsResolverTrait
+{
+    /**
+     * Resolve an `expression` field into its trimmed string value.
+     */
+    private function resolveExpressionField(array $nodeSettings, string $fieldName): string
+    {
+        $value = $nodeSettings[$fieldName] ?? '';
+
+        if (is_array($value)) {
+            $value = $value['expression'] ?? '';
+        }
+
+        return trim($this->executionContext->resolveExpressionsInText((string)$value));
+    }
+
+    /**
+     * Resolve a comma-separated list of author references into Author objects.
+     *
+     * @return Author[]
+     */
+    private function resolveAuthors(string $referenceList): array
+    {
+        if (! class_exists(Author::class)) {
+            return [];
+        }
+
+        $authors = [];
+
+        foreach (array_filter(array_map('trim', explode(',', $referenceList))) as $reference) {
+            $author = $this->resolveSingleAuthor($reference);
+
+            if ($author && ! empty($author->term_id)) {
+                $authors[(int) $author->term_id] = $author;
+            }
+        }
+
+        return array_values($authors);
+    }
+
+    private function resolveSingleAuthor(string $reference)
+    {
+        if (ctype_digit($reference)) {
+            return Author::get_by_term_id((int) $reference);
+        }
+
+        if (strpos($reference, '@') !== false) {
+            return Author::get_by_email($reference);
+        }
+
+        return Author::get_by_term_slug($reference);
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/RemovePostAuthorRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/RemovePostAuthorRunner.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use MultipleAuthors\Classes\Utils;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\RemovePostAuthor;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class RemovePostAuthorRunner implements StepRunnerInterface
+{
+    use AuthorsResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return RemovePostAuthor::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $postId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $postId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! class_exists(Utils::class) || ! function_exists('get_post_authors')) {
+                    $this->logger->debugWithArgs('PublishPress Authors not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $toRemove = $this->resolveAuthors($this->resolveExpressionField($nodeSettings, 'authors'));
+                if (empty($toRemove)) {
+                    $this->logger->debugWithArgs('No authors resolved, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $removeIds = [];
+                foreach ($toRemove as $author) {
+                    $removeIds[(int) $author->term_id] = true;
+                }
+
+                $remaining = [];
+                foreach (get_post_authors($postId) as $author) {
+                    if (! empty($author->term_id) && ! isset($removeIds[(int) $author->term_id])) {
+                        $remaining[] = $author;
+                    }
+                }
+
+                Utils::set_post_authors($postId, $remaining);
+
+                $this->logger->debugWithArgs(
+                    'Removed %1$d author(s) from post | Post ID: %2$s | Slug: %3$s',
+                    count($toRemove),
+                    $postId,
+                    $nodeSlug
+                );
+            },
+            $postId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/SetPostAuthorsRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/SetPostAuthorsRunner.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use MultipleAuthors\Classes\Utils;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\SetPostAuthors;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class SetPostAuthorsRunner implements StepRunnerInterface
+{
+    use AuthorsResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return SetPostAuthors::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(int $postId, array $nodeSettings, array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step, $postId, $nodeSettings) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! class_exists(Utils::class)) {
+                    $this->logger->debugWithArgs('PublishPress Authors not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $authors = $this->resolveAuthors($this->resolveExpressionField($nodeSettings, 'authors'));
+
+                if (empty($authors)) {
+                    $this->logger->debugWithArgs(
+                        'No authors resolved, skipping to avoid clearing authors | Slug: %1$s',
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                Utils::set_post_authors($postId, $authors);
+
+                $this->logger->debugWithArgs(
+                    'Post authors set (%1$d authors) | Post ID: %2$s | Slug: %3$s',
+                    count($authors),
+                    $postId,
+                    $nodeSlug
+                );
+            },
+            $postId,
+            $nodeSettings
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnPostAuthorsChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnPostAuthorsChanged.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnPostAuthorsChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.post-authors-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onPostAuthorsChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Post authors are changed", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a post's PublishPress Authors are changed.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "groups";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "authors";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "post",
+                "type" => "post",
+                "label" => __("Post", "post-expirator"),
+                "description" => __("The post whose authors changed.", "post-expirator"),
+            ],
+            [
+                "name" => "postId",
+                "type" => "integer",
+                "label" => __("Post ID", "post-expirator"),
+                "description" => __("The ID of the post whose authors changed.", "post-expirator"),
+            ],
+            [
+                "name" => "authors",
+                "type" => "array",
+                "label" => __("Author names", "post-expirator"),
+                "description" => __("The display names of the post's authors.", "post-expirator"),
+            ],
+            [
+                "name" => "authorEmails",
+                "type" => "array",
+                "label" => __("Author emails", "post-expirator"),
+                "description" => __("The email addresses of the post's authors.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                [
+                    "id" => "output",
+                    "label" => __("Next", "post-expirator"),
+                ]
+            ]
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnPostAuthorsChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnPostAuthorsChangedRunner.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\ArrayResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\PostResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostAuthorsChanged;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnPostAuthorsChangedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        \Closure $expirablePostModelFactory,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnPostAuthorsChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_PPMA_AUTHORS_SAVED,
+            [$this, 'onAuthorsSavedCallback'],
+            20,
+            1
+        );
+    }
+
+    public function onAuthorsSavedCallback($postId): void
+    {
+        $postId = (int) $postId;
+
+        $post = get_post($postId);
+        if (! ($post instanceof \WP_Post)) {
+            return;
+        }
+
+        $names = [];
+        $emails = [];
+        if (function_exists('get_post_authors')) {
+            foreach (get_post_authors($postId) as $author) {
+                if (! empty($author->display_name)) {
+                    $names[] = $author->display_name;
+                }
+                $email = isset($author->user_email) ? (string) $author->user_email : '';
+                if ($email !== '') {
+                    $emails[] = $email;
+                }
+            }
+        }
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'post' => new PostResolver($post, $this->hooks, '', $this->expirablePostModelFactory),
+            'postId' => new IntegerResolver($postId),
+            'authors' => new ArrayResolver($names),
+            'authorEmails' => new ArrayResolver($emails),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $postId);
+
+        if ($this->shouldAbortExecution($postId)) {
+            $this->logger->debugWithArgs(
+                'Trigger skipped: Execution should be aborted for step "%s" and post #%d.',
+                $this->stepSlug,
+                $postId
+            );
+
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $postId
+        );
+    }
+
+    private function shouldAbortExecution(int $postId): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $postId,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and post #%d.',
+                $this->stepSlug,
+                $postId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $postId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for post #%d.', $this->stepSlug, $postId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/HooksAbstract.php
+++ b/src/Modules/Workflows/HooksAbstract.php
@@ -57,6 +57,11 @@ abstract class HooksAbstract
     public const ACTION_TRIGGER_FIRED = 'publishpressfuture_workflow_trigger_fired_';
 
     /**
+     * Fired by PublishPress Authors after a post's authors are saved.
+     */
+    public const ACTION_PPMA_AUTHORS_SAVED = 'publishpress_authors_post_authors_metabox_action_saved';
+
+    /**
      * @deprecated 4.3.2 Use ACTION_EXECUTE_STEP instead.
      */
     public const ACTION_EXECUTE_NODE = 'publishpressfuture_workflow_execute_node';

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -27,6 +27,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Unsti
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdatePost;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdatePostMeta;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DuplicatePost;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\SetPostAuthors;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\AddPostAuthor;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\RemovePostAuthor;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnAdminInit;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCustomAction;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnTermsAdded;
@@ -44,6 +47,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostWorkflowEnable;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnSchedule;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserRoleChange;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostAuthorsChanged;
 use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
 
@@ -84,7 +88,7 @@ class StepTypesModel implements StepTypesModelInterface
 
     private function getDefaultCategories()
     {
-        return [
+        $categories = [
             [
                 "name" => "post",
                 "label" => __("Post", "post-expirator"),
@@ -168,6 +172,20 @@ class StepTypesModel implements StepTypesModelInterface
 
             ]
         ];
+
+        if (class_exists('MultipleAuthors\\Classes\\Utils')) {
+            $categories[] = [
+                "name" => "authors",
+                "label" => __("Authors", "post-expirator"),
+                "icon" => [
+                    "src" => "groups",
+                    "background" => self::DEFAULT_ICON_BACKGROUND,
+                    "foreground" => self::DEFAULT_ICON_FOREGROUND,
+                ],
+            ];
+        }
+
+        return $categories;
     }
 
     public function convertInstancesToArray($instances, $type): array
@@ -231,6 +249,10 @@ class StepTypesModel implements StepTypesModelInterface
             OnCustomAction::getNodeTypeName() => new OnCustomAction(),
         ];
 
+        if (class_exists('MultipleAuthors\\Classes\\Utils')) {
+            $nodesInstances[OnPostAuthorsChanged::getNodeTypeName()] = new OnPostAuthorsChanged();
+        }
+
         if ($this->settingsFacade->getExperimentalFeaturesStatus()) {
             $nodesInstances[OnInit::getNodeTypeName()] = new OnInit();
             $nodesInstances[OnAdminInit::getNodeTypeName()] = new OnAdminInit();
@@ -258,6 +280,12 @@ class StepTypesModel implements StepTypesModelInterface
             SendInSiteNotification::getNodeTypeName() => new SendInSiteNotification(),
             DuplicatePost::getNodeTypeName() => new DuplicatePost(),
         ];
+
+        if (class_exists('MultipleAuthors\\Classes\\Utils')) {
+            $nodesInstances[SetPostAuthors::getNodeTypeName()] = new SetPostAuthors();
+            $nodesInstances[AddPostAuthor::getNodeTypeName()] = new AddPostAuthor();
+            $nodesInstances[RemovePostAuthor::getNodeTypeName()] = new RemovePostAuthor();
+        }
 
         return $nodesInstances;
     }


### PR DESCRIPTION
## Summary

Integrates **PublishPress Authors** with Action Workflows — the first cross-plugin integration. Everything is gated on Authors being active (`class_exists('MultipleAuthors\Classes\Utils')`) and ships **working in free** (Authors is a free plugin).

### Actions (operate on a target post's authors)
| Action | Node type | API |
|---|---|---|
| Set post authors | `action/core.set-post-authors` | `Utils::set_post_authors()` (replaces) |
| Add post author | `action/core.add-post-author` | merge with existing, dedup by term |
| Remove post author | `action/core.remove-post-author` | filter out by term |

Authors are entered as a comma-separated list of **slugs, emails, or term IDs** (expression fields, so `{{...}}` variables work), resolved via `Author::get_by_term_slug` / `get_by_email` / `get_by_term_id`. Target post uses the standard `postInput` field + Post step processor — same pattern as Change Post Status.

### Trigger
- **"Post authors are changed"** (`trigger/core.post-authors-changed`) — fires on `publishpress_authors_post_authors_metabox_action_saved`, exposing the **post** plus **author names** and **author emails** as step variables. This fills a real gap: Future's existing `OnPostAuthorChange` watches only WordPress's core single `post_author`, not the PublishPress Authors multi-author taxonomy.

### Variables
- `PostResolver` gains **`ppma_authors`** and **`ppma_author_emails`** properties (guarded by `function_exists('get_post_authors')`), so *any* post-bearing workflow can reference a post's authors — e.g. **"email all co-authors"** via `{{trigger.post.ppma_author_emails}}` in a Send Email step.

Adds an **"Authors"** node category and the `ACTION_PPMA_AUTHORS_SAVED` hook constant.

## Design notes
- **No new JS field type** — reuses `postInput` (target) + `expression` (author refs), consistent with the WooCommerce work.
- Authorship is the `author` taxonomy; writes go through `Utils::set_post_authors()` (not raw term writes) so Authors' caches/relationships and the author-category table stay correct.
- "Set" skips when no authors resolve, to avoid accidentally clearing a post's authorship.
- Gated at registration (nodes + category) and again at runtime in each runner.

## Files
- New: 3 action definitions, 3 action runners, `AuthorsResolverTrait`, 1 trigger definition, 1 trigger runner.
- Modified: `PostResolver.php` (2 properties), `services.php` (4 cases + imports), `StepTypesModel.php` (registration + category + imports), `HooksAbstract.php` (hook constant).
- 13 files, all pass `php -l`.

## Test plan
- [ ] With Authors active, the 3 actions + trigger + "Authors" category appear; with it inactive, none do.
- [ ] Set/Add/Remove authors by slug, email, and term ID.
- [ ] Guest authors (no linked user) resolve and assign correctly.
- [ ] "Post authors are changed" fires when authorship is saved and exposes names/emails.
- [ ] Send Email using `{{trigger.post.ppma_author_emails}}` reaches all co-authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)