### PR TITLE
Add PublishPress Cart actions (order status, cancel subscription, duplicate product)

### DIFF
--- a/services.php
+++ b/services.php
@@ -100,6 +100,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SendRayRu
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\SetPostTermRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostMetaRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePostRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartChangeOrderStatusRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartCancelSubscriptionRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartDuplicateProductRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -1232,6 +1235,30 @@ return [
                     $stepRunner = new SendEmailRunner(
                         $generalStepProcessor,
                         $container->get(ServicesAbstract::EMAIL),
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case NcsCartChangeOrderStatusRunner::getNodeTypeName():
+                    $stepRunner = new NcsCartChangeOrderStatusRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case NcsCartCancelSubscriptionRunner::getNodeTypeName():
+                    $stepRunner = new NcsCartCancelSubscriptionRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case NcsCartDuplicateProductRunner::getNodeTypeName():
+                    $stepRunner = new NcsCartDuplicateProductRunner(
+                        $generalStepProcessor,
                         $executionContext,
                         $workflowLogger
                     );

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartCancelSubscription.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartCancelSubscription.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class NcsCartCancelSubscription implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.ncscart-subscription-cancel";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "ncsCartCancelSubscription";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Cancel Cart subscription", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step cancels a PublishPress Cart subscription.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Subscription", "post-expirator"),
+                "description" => __("The subscription to cancel.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "subscriptionId",
+                        "type" => "expression",
+                        "label" => __("Subscription ID", "post-expirator"),
+                        "description" => __("The ID of the Cart subscription to cancel.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "when",
+                        "type" => "select",
+                        "label" => __("Cancel", "post-expirator"),
+                        "description" => __(
+                            "Cancel immediately, or at the end of the current billing period.",
+                            "post-expirator"
+                        ),
+                        "settings" => [
+                            "options" => [
+                                ["value" => "now", "label" => __("Immediately", "post-expirator")],
+                                ["value" => "period_end", "label" => __("At period end", "post-expirator")],
+                            ],
+                        ],
+                        "default" => "now",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "subscriptionId"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartChangeOrderStatus.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartChangeOrderStatus.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class NcsCartChangeOrderStatus implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.ncscart-order-change-status";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "ncsCartChangeOrderStatus";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Change Cart order status", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step changes the status of a PublishPress Cart order.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Order", "post-expirator"),
+                "description" => __("The order to update.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "orderId",
+                        "type" => "expression",
+                        "label" => __("Order ID", "post-expirator"),
+                        "description" => __("The ID of the Cart order to update.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "status",
+                        "type" => "select",
+                        "label" => __("New status", "post-expirator"),
+                        "settings" => [
+                            "options" => [
+                                ["value" => "pending-payment", "label" => __("Pending", "post-expirator")],
+                                ["value" => "paid", "label" => __("Paid", "post-expirator")],
+                                ["value" => "completed", "label" => __("Completed", "post-expirator")],
+                                ["value" => "refunded", "label" => __("Refunded", "post-expirator")],
+                                ["value" => "failed", "label" => __("Failed", "post-expirator")],
+                            ],
+                        ],
+                        "default" => "completed",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "orderId"],
+                    ["rule" => "required", "field" => "status"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartDuplicateProduct.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartDuplicateProduct.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class NcsCartDuplicateProduct implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.ncscart-product-duplicate";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "ncsCartDuplicateProduct";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Duplicate Cart product", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step duplicates a PublishPress Cart product.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Product", "post-expirator"),
+                "description" => __("The product to duplicate.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "productId",
+                        "type" => "expression",
+                        "label" => __("Product ID", "post-expirator"),
+                        "description" => __("The ID of the Cart product to duplicate.", "post-expirator"),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "productId"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "productId",
+                "type" => "integer",
+                "label" => __("Duplicated product ID", "post-expirator"),
+                "description" => __("The ID of the newly created product.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return array_merge(
+            [
+                [
+                    "name" => "input",
+                    "type" => "input",
+                    "label" => __("Step input", "post-expirator"),
+                    "description" => __("The input data for this step.", "post-expirator"),
+                ],
+            ],
+            $this->getStepScopedVariablesSchema()
+        );
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartCancelSubscriptionRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartCancelSubscriptionRunner.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartCancelSubscription;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class NcsCartCancelSubscriptionRunner implements StepRunnerInterface
+{
+    use NcsCartResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return NcsCartCancelSubscription::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('sc_do_cancel_subscription')) {
+                    $this->logger->debugWithArgs('PublishPress Cart not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $subscriptionId = $this->resolveExpressionField($nodeSettings, 'subscriptionId');
+                if ($subscriptionId === '' || ! ctype_digit($subscriptionId)) {
+                    $this->logger->debugWithArgs('No valid subscription ID, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+                $subscriptionId = (int) $subscriptionId;
+
+                if (get_post_type($subscriptionId) !== 'sc_subscription') {
+                    $this->logger->debugWithArgs(
+                        'Post %1$s is not a Cart subscription, skipping | Slug: %2$s',
+                        $subscriptionId,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $when = $nodeSettings['when'] ?? 'now';
+                if (is_array($when)) {
+                    $when = $when['value'] ?? 'now';
+                }
+                $cancelNow = ($when !== 'period_end');
+
+                // sc_do_cancel_subscription($sub, $sub_id, $now, $echo, $options)
+                // A numeric first arg is turned into an NCS_Cart_Subscription internally.
+                // $echo = false so nothing is printed during workflow execution.
+                sc_do_cancel_subscription($subscriptionId, false, $cancelNow, false);
+
+                $this->logger->debugWithArgs(
+                    'Cart subscription %1$s cancelled (%2$s) | Slug: %3$s',
+                    $subscriptionId,
+                    $cancelNow ? 'immediately' : 'at period end',
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartChangeOrderStatusRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartChangeOrderStatusRunner.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartChangeOrderStatus;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class NcsCartChangeOrderStatusRunner implements StepRunnerInterface
+{
+    use NcsCartResolverTrait;
+
+    private const VALID_STATUSES = ['pending-payment', 'paid', 'completed', 'refunded', 'failed'];
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return NcsCartChangeOrderStatus::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('sc_setup_order')) {
+                    $this->logger->debugWithArgs('PublishPress Cart not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $orderId = $this->resolveExpressionField($nodeSettings, 'orderId');
+                if ($orderId === '' || ! ctype_digit($orderId)) {
+                    $this->logger->debugWithArgs('No valid order ID, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+                $orderId = (int) $orderId;
+
+                if (get_post_type($orderId) !== 'sc_order') {
+                    $this->logger->debugWithArgs(
+                        'Post %1$s is not a Cart order, skipping | Slug: %2$s',
+                        $orderId,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $status = $nodeSettings['status'] ?? '';
+                if (is_array($status)) {
+                    $status = $status['value'] ?? '';
+                }
+                $status = is_string($status) ? trim($status) : '';
+
+                if (! in_array($status, self::VALID_STATUSES, true)) {
+                    $this->logger->debugWithArgs('Invalid status "%1$s", skipping | Slug: %2$s', $status, $nodeSlug);
+                    return;
+                }
+
+                update_post_meta($orderId, '_sc_status', $status);
+
+                $this->logger->debugWithArgs(
+                    'Cart order %1$s status set to %2$s | Slug: %3$s',
+                    $orderId,
+                    $status,
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartDuplicateProductRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartDuplicateProductRunner.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartDuplicateProduct;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class NcsCartDuplicateProductRunner implements StepRunnerInterface
+{
+    use NcsCartResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return NcsCartDuplicateProduct::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! class_exists('NCS_Cart_Product_Duplicator')) {
+                    $this->logger->debugWithArgs('PublishPress Cart not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $productId = $this->resolveExpressionField($nodeSettings, 'productId');
+                if ($productId === '' || ! ctype_digit($productId)) {
+                    $this->logger->debugWithArgs('No valid product ID, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+                $productId = (int) $productId;
+
+                $newProductId = \NCS_Cart_Product_Duplicator::duplicate($productId);
+
+                if (! is_numeric($newProductId) || (int) $newProductId <= 0) {
+                    $this->logger->debugWithArgs(
+                        'Failed to duplicate product %1$s | Slug: %2$s',
+                        $productId,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $this->executionContext->setVariable($nodeSlug, [
+                    'productId' => new IntegerResolver((int) $newProductId),
+                ]);
+
+                $this->logger->debugWithArgs(
+                    'Cart product %1$s duplicated to %2$s | Slug: %3$s',
+                    $productId,
+                    (int) $newProductId,
+                    $nodeSlug
+                );
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartResolverTrait.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartResolverTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+/**
+ * Shared helper for PublishPress Cart action runners: reads an `expression`
+ * field and resolves {{...}} variables through the execution context.
+ * Requires the using class to expose an $executionContext property.
+ */
+trait NcsCartResolverTrait
+{
+    private function resolveExpressionField(array $nodeSettings, string $fieldName): string
+    {
+        $value = $nodeSettings[$fieldName] ?? '';
+
+        if (is_array($value)) {
+            $value = $value['expression'] ?? '';
+        }
+
+        return trim($this->executionContext->resolveExpressionsInText((string)$value));
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -27,6 +27,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Unsti
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdatePost;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\UpdatePostMeta;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\DuplicatePost;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartChangeOrderStatus;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartCancelSubscription;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartDuplicateProduct;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnAdminInit;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCustomAction;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnTermsAdded;
@@ -84,7 +87,7 @@ class StepTypesModel implements StepTypesModelInterface
 
     private function getDefaultCategories()
     {
-        return [
+        $categories = [
             [
                 "name" => "post",
                 "label" => __("Post", "post-expirator"),
@@ -168,6 +171,20 @@ class StepTypesModel implements StepTypesModelInterface
 
             ]
         ];
+
+        if (function_exists('sc_setup_order')) {
+            $categories[] = [
+                "name" => "publishpress-cart",
+                "label" => __("PublishPress Cart", "post-expirator"),
+                "icon" => [
+                    "src" => "cart",
+                    "background" => self::DEFAULT_ICON_BACKGROUND,
+                    "foreground" => self::DEFAULT_ICON_FOREGROUND,
+                ],
+            ];
+        }
+
+        return $categories;
     }
 
     public function convertInstancesToArray($instances, $type): array
@@ -258,6 +275,12 @@ class StepTypesModel implements StepTypesModelInterface
             SendInSiteNotification::getNodeTypeName() => new SendInSiteNotification(),
             DuplicatePost::getNodeTypeName() => new DuplicatePost(),
         ];
+
+        if (function_exists('sc_setup_order')) {
+            $nodesInstances[NcsCartChangeOrderStatus::getNodeTypeName()] = new NcsCartChangeOrderStatus();
+            $nodesInstances[NcsCartCancelSubscription::getNodeTypeName()] = new NcsCartCancelSubscription();
+            $nodesInstances[NcsCartDuplicateProduct::getNodeTypeName()] = new NcsCartDuplicateProduct();
+        }
 
         return $nodesInstances;
     }


### PR DESCRIPTION
## Summary

First **PublishPress Cart** (Studio Cart) integration for Action Workflows — three native, free actions:

| Action | Node type | Cart API |
|---|---|---|
| Change Cart order status | `action/core.ncscart-order-change-status` | `update_post_meta($id, '_sc_status', $status)` on `sc_order` |
| Cancel Cart subscription | `action/core.ncscart-subscription-cancel` | `sc_do_cancel_subscription($id, false, $now, false)` on `sc_subscription` |
| Duplicate Cart product | `action/core.ncscart-product-duplicate` | `NCS_Cart_Product_Duplicator::duplicate($id)` |

Chosen from an analysis of the Cart codebase as the cleanest native levers that fit Future's scheduled-automation model (e.g. "cancel a subscription after N failed payments", "mark unpaid orders failed after N days").

## Design
- **Order status** uses `update_post_meta(_sc_status)` — exactly how Cart's own `includes/stripe/templates/order-save.php` persists status. Order statuses: `pending-payment / paid / completed / refunded / failed`.
- **Cancel subscription** calls Cart's free helper `sc_do_cancel_subscription()` with a numeric ID (it constructs `NCS_Cart_Subscription` internally) and `$echo = false` so nothing prints during workflow execution; "immediately" vs "at period end" maps to the `$now` arg.
- **Duplicate product** calls the static duplicator and exposes the new product ID as a step output variable.
- Targets are `expression` fields (order/subscription/product ID) — supports literals and `{{...}}` variables; no new JS field type.
- **Cart-gated**: nodes + a "PublishPress Cart" node category register only when `function_exists('sc_setup_order')`; each runner guards again at runtime with the specific function/class it calls, and validates the target post type (`sc_order` / `sc_subscription`).

All ship working in free (`isProFeature() = false`).

## Notes
- PublishPress Cart is a rebranded **Studio Cart** (`sc_*` helpers, `NCS_` classes, `sc_order`/`sc_subscription`/product CPTs, Stripe-backed).
- Refund + subscription-cancel-with-refund were intentionally deferred — refund logic lives partly under `includes/integrations/pro/` and is Stripe-dependent, so it belongs in a follow-up (likely gated/Pro).
- Changing order status writes the status meta directly (matching Cart core). If Cart later exposes a higher-level "transition status + fire integrations" API, the runner should switch to it.

## Files
- New: `NcsCartResolverTrait`, 3 definitions, 3 runners.
- Modified: `services.php` (3 cases + imports), `StepTypesModel.php` (gated registration + category + imports).
- 9 files, all pass `php -l`.

## Test plan
- [ ] With Cart active, the 3 actions + a "PublishPress Cart" category appear; with it inactive, none do.
- [ ] Change an `sc_order` to each status; confirm `_sc_status` updates and Cart reflects it.
- [ ] Cancel an `sc_subscription` immediately and at period end.
- [ ] Duplicate a product; confirm a new product is created and the output ID is usable downstream.
- [ ] Non-Cart post IDs are rejected with a debug log, not a fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)