### PR TITLE
Add PublishPress Cart triggers (order created, refunded, subscription status)

### DIFF
--- a/services.php
+++ b/services.php
@@ -118,6 +118,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostUp
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostWorkflowEnableRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnScheduleRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserRoleChangeRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnCartOrderCreatedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnCartOrderRefundedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnCartSubscriptionStatusChangedRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnTermsAddedRunner;
 use PublishPress\Future\Modules\Workflows\HooksAbstract as WorkflowsHooksAbstract;
 use PublishPress\Future\Modules\Workflows\Logger\WorkflowLogger;
@@ -1118,6 +1121,39 @@ return [
                     $stepRunner = new OnUserRoleChangeRunner(
                         $generalStepProcessor,
                         $workflowLogger
+                    );
+                    break;
+
+                case OnCartOrderCreatedRunner::getNodeTypeName():
+                    $stepRunner = new OnCartOrderCreatedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
+                    );
+                    break;
+
+                case OnCartOrderRefundedRunner::getNodeTypeName():
+                    $stepRunner = new OnCartOrderRefundedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
+                    );
+                    break;
+
+                case OnCartSubscriptionStatusChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnCartSubscriptionStatusChangedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
                     );
                     break;
 

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnCartOrderCreated.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnCartOrderCreated.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnCartOrderCreated implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.ncscart-order-created";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onCartOrderCreated";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Cart order is created", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This trigger activates when a PublishPress Cart order is created.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "post",
+                "type" => "post",
+                "label" => __("Order post", "post-expirator"),
+                "description" => __("The order post that was created.", "post-expirator"),
+            ],
+            [
+                "name" => "orderId",
+                "type" => "integer",
+                "label" => __("Order ID", "post-expirator"),
+                "description" => __("The ID of the order that was created.", "post-expirator"),
+            ],
+            [
+                "name" => "status",
+                "type" => "string",
+                "label" => __("Order status", "post-expirator"),
+                "description" => __("The status of the created order.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnCartOrderRefunded.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnCartOrderRefunded.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnCartOrderRefunded implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.ncscart-order-refunded";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onCartOrderRefunded";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Cart order is refunded", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This trigger activates when a PublishPress Cart order is refunded.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "post",
+                "type" => "post",
+                "label" => __("Order post", "post-expirator"),
+                "description" => __("The order post that was refunded.", "post-expirator"),
+            ],
+            [
+                "name" => "orderId",
+                "type" => "integer",
+                "label" => __("Order ID", "post-expirator"),
+                "description" => __("The ID of the refunded order.", "post-expirator"),
+            ],
+            [
+                "name" => "refundAmount",
+                "type" => "string",
+                "label" => __("Refund amount", "post-expirator"),
+                "description" => __("The amount that was refunded.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnCartSubscriptionStatusChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnCartSubscriptionStatusChanged.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnCartSubscriptionStatusChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.ncscart-subscription-status-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onCartSubscriptionStatusChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Cart subscription status changes", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a PublishPress Cart subscription is created or its status changes "
+            . "(for example active, paused, canceled, past due).",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "post",
+                "type" => "post",
+                "label" => __("Subscription post", "post-expirator"),
+                "description" => __("The subscription post.", "post-expirator"),
+            ],
+            [
+                "name" => "subscriptionId",
+                "type" => "integer",
+                "label" => __("Subscription ID", "post-expirator"),
+                "description" => __("The ID of the subscription.", "post-expirator"),
+            ],
+            [
+                "name" => "status",
+                "type" => "string",
+                "label" => __("Subscription status", "post-expirator"),
+                "description" => __("The current status of the subscription.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnCartOrderCreatedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnCartOrderCreatedRunner.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\PostResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCartOrderCreated;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnCartOrderCreatedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        \Closure $expirablePostModelFactory,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnCartOrderCreated::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_SC_AFTER_ORDER_CREATED,
+            [$this, 'onOrderCreatedCallback'],
+            20,
+            3
+        );
+    }
+
+    public function onOrderCreatedCallback($postId, $status = '', $order = null): void
+    {
+        $postId = (int) $postId;
+
+        // studiocart_after_order_created fires for both sc_order and sc_subscription posts.
+        if (get_post_type($postId) !== 'sc_order') {
+            return;
+        }
+
+        $post = get_post($postId);
+        if (! ($post instanceof \WP_Post)) {
+            return;
+        }
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'post' => new PostResolver($post, $this->hooks, '', $this->expirablePostModelFactory),
+            'orderId' => new IntegerResolver($postId),
+            'status' => new StringResolver((string) $status),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $postId);
+
+        if ($this->shouldAbortExecution($postId)) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $postId
+        );
+    }
+
+    private function shouldAbortExecution(int $postId): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $postId,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and order #%d.',
+                $this->stepSlug,
+                $postId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $postId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for Cart order #%d.', $this->stepSlug, $postId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnCartOrderRefundedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnCartOrderRefundedRunner.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\PostResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCartOrderRefunded;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnCartOrderRefundedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        \Closure $expirablePostModelFactory,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnCartOrderRefunded::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_SC_BEFORE_ORDER_REFUND,
+            [$this, 'onOrderRefundCallback'],
+            20,
+            1
+        );
+    }
+
+    /**
+     * Fires on `before_sc_order_refund`. $data['id'] is the order post ID.
+     *
+     * @param array $data
+     */
+    public function onOrderRefundCallback($data): void
+    {
+        $data = is_array($data) ? $data : [];
+        $orderId = (int) ($data['id'] ?? 0);
+
+        if ($orderId <= 0) {
+            return;
+        }
+
+        $post = get_post($orderId);
+        if (! ($post instanceof \WP_Post)) {
+            return;
+        }
+
+        $refundAmount = isset($data['refund_amount']) ? (string) $data['refund_amount'] : '';
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'post' => new PostResolver($post, $this->hooks, '', $this->expirablePostModelFactory),
+            'orderId' => new IntegerResolver($orderId),
+            'refundAmount' => new StringResolver($refundAmount),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $orderId);
+
+        if ($this->shouldAbortExecution($orderId)) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $orderId
+        );
+    }
+
+    private function shouldAbortExecution(int $orderId): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $orderId,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and order #%d.',
+                $this->stepSlug,
+                $orderId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $orderId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for Cart order refund #%d.', $this->stepSlug, $orderId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnCartSubscriptionStatusChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnCartSubscriptionStatusChangedRunner.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\PostResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCartSubscriptionStatusChanged;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnCartSubscriptionStatusChangedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        \Closure $expirablePostModelFactory,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnCartSubscriptionStatusChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_SC_AFTER_ORDER_CREATED,
+            [$this, 'onSubscriptionSavedCallback'],
+            20,
+            3
+        );
+    }
+
+    public function onSubscriptionSavedCallback($postId, $status = '', $order = null): void
+    {
+        $postId = (int) $postId;
+
+        // studiocart_after_order_created fires for both sc_order and sc_subscription posts.
+        if (get_post_type($postId) !== 'sc_subscription') {
+            return;
+        }
+
+        $post = get_post($postId);
+        if (! ($post instanceof \WP_Post)) {
+            return;
+        }
+
+        if ($status === '' || $status === null) {
+            $status = (string) get_post_meta($postId, '_sc_status', true);
+        }
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'post' => new PostResolver($post, $this->hooks, '', $this->expirablePostModelFactory),
+            'subscriptionId' => new IntegerResolver($postId),
+            'status' => new StringResolver((string) $status),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $postId);
+
+        if ($this->shouldAbortExecution($postId, (string) $status)) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $postId
+        );
+    }
+
+    private function shouldAbortExecution(int $postId, string $status): bool
+    {
+        // Key on status too, so distinct status transitions of the same subscription are not deduped.
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $postId,
+            $status,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and subscription #%d.',
+                $this->stepSlug,
+                $postId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $postId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for Cart subscription #%d.', $this->stepSlug, $postId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/HooksAbstract.php
+++ b/src/Modules/Workflows/HooksAbstract.php
@@ -57,6 +57,16 @@ abstract class HooksAbstract
     public const ACTION_TRIGGER_FIRED = 'publishpressfuture_workflow_trigger_fired_';
 
     /**
+     * Fired by PublishPress Cart (Studio Cart) after an order or subscription is created/saved.
+     */
+    public const ACTION_SC_AFTER_ORDER_CREATED = 'studiocart_after_order_created';
+
+    /**
+     * Fired by PublishPress Cart (Studio Cart) before an order refund is processed.
+     */
+    public const ACTION_SC_BEFORE_ORDER_REFUND = 'before_sc_order_refund';
+
+    /**
      * @deprecated 4.3.2 Use ACTION_EXECUTE_STEP instead.
      */
     public const ACTION_EXECUTE_NODE = 'publishpressfuture_workflow_execute_node';

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -47,6 +47,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostWorkflowEnable;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnSchedule;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserRoleChange;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCartOrderCreated;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCartOrderRefunded;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCartSubscriptionStatusChanged;
 use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
 
@@ -247,6 +250,13 @@ class StepTypesModel implements StepTypesModelInterface
             OnTermsAdded::getNodeTypeName() => new OnTermsAdded(),
             OnCustomAction::getNodeTypeName() => new OnCustomAction(),
         ];
+
+        if (function_exists('sc_setup_order')) {
+            $nodesInstances[OnCartOrderCreated::getNodeTypeName()] = new OnCartOrderCreated();
+            $nodesInstances[OnCartOrderRefunded::getNodeTypeName()] = new OnCartOrderRefunded();
+            $nodesInstances[OnCartSubscriptionStatusChanged::getNodeTypeName()] =
+                new OnCartSubscriptionStatusChanged();
+        }
 
         if ($this->settingsFacade->getExperimentalFeaturesStatus()) {
             $nodesInstances[OnInit::getNodeTypeName()] = new OnInit();


### PR DESCRIPTION
## Summary

Adds three **PublishPress Cart** (Studio Cart) triggers to Action Workflows, completing the Cart integration alongside the actions PR:

| Trigger | Node type | Cart hook |
|---|---|---|
| Cart order is created | `trigger/core.ncscart-order-created` | `studiocart_after_order_created` (filtered to `sc_order`) |
| Cart order is refunded | `trigger/core.ncscart-order-refunded` | `before_sc_order_refund` (`$data['id']` = order ID) |
| Cart subscription status changes | `trigger/core.ncscart-subscription-status-changed` | `studiocart_after_order_created` (filtered to `sc_subscription`) |

> **Stacked on the Cart actions PR** (#1671). Base this on `feature/publishpress-cart-actions`; merge that first. Reuses the "PublishPress Cart" node category and `function_exists('sc_setup_order')` gating introduced there.

## How the hooks map
- `studiocart_after_order_created($post_id, $status, $order)` fires for **both** `sc_order` and `sc_subscription` posts — so the **order-created** and **subscription-status** triggers share it and branch on `get_post_type()`. Confirmed at two call sites (`stripe/templates/order-save.php`, `stripe/traits/trait-ncs-cart-stripe-subscription-save.php`).
- **Refund**: `before_sc_order_refund($data)` is the stable (non-dynamic) refund hook; `$data['id']` is the order post ID and `$data['refund_amount']` the amount (verified in `payment-actions-and-refunds.php` / `sc_order_refund()`).
- **Subscriptions**: Cart has **no dedicated subscription-cancel/renew `do_action`** — cancellation via `sc_do_cancel_subscription()` fires no lifecycle hook. So the subscription trigger keys on status changes captured by the save hook (active / paused / canceled / past_due / trialing), letting a downstream Conditional branch on the status. This is the honest best-available signal; noted here so reviewers know why it isn't a literal "subscription cancelled" event.

## Details
- Each trigger exposes the **post** (via `PostResolver`) plus `orderId`/`subscriptionId` and `status` (or `refundAmount`) as step variables.
- Dedup safeguard keys on workflow + node + post ID; the subscription trigger **also keys on status** so distinct transitions of the same subscription each fire.
- Adds `ACTION_SC_AFTER_ORDER_CREATED` + `ACTION_SC_BEFORE_ORDER_REFUND` hook constants. Registered only when Cart is active.

## Files
- New: 3 trigger definitions, 3 trigger runners.
- Modified: `services.php` (3 cases + imports), `StepTypesModel.php` (gated registration + imports), `HooksAbstract.php` (2 constants).
- 9 files, all pass `php -l`.

## Test plan
- [ ] With Cart active, the 3 triggers appear under "PublishPress Cart"; with it inactive, none do.
- [ ] Completing a checkout fires "Cart order is created" with the order ID + status.
- [ ] Refunding an order fires "Cart order is refunded" with order ID + amount.
- [ ] A subscription going active → canceled fires the subscription trigger with the new status each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)