### PR TITLE
Add PublishPress Cart refund order action

### DIFF
--- a/services.php
+++ b/services.php
@@ -103,6 +103,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\UpdatePos
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartChangeOrderStatusRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartCancelSubscriptionRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartDuplicateProductRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners\NcsCartRefundOrderRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnAdminInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnInitRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnLegacyActionTriggerRunner;
@@ -1258,6 +1259,14 @@ return [
 
                 case NcsCartDuplicateProductRunner::getNodeTypeName():
                     $stepRunner = new NcsCartDuplicateProductRunner(
+                        $generalStepProcessor,
+                        $executionContext,
+                        $workflowLogger
+                    );
+                    break;
+
+                case NcsCartRefundOrderRunner::getNodeTypeName():
+                    $stepRunner = new NcsCartRefundOrderRunner(
                         $generalStepProcessor,
                         $executionContext,
                         $workflowLogger

--- a/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartRefundOrder.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Definitions/NcsCartRefundOrder.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class NcsCartRefundOrder implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "action/core.ncscart-order-refund";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_ACTION;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "generic";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "ncsCartRefundOrder";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Refund Cart order", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This step refunds a PublishPress Cart order, fully or partially.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "publishpress-cart";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [
+            [
+                "label" => __("Order", "post-expirator"),
+                "description" => __("The order to refund.", "post-expirator"),
+                "fields" => [
+                    [
+                        "name" => "orderId",
+                        "type" => "expression",
+                        "label" => __("Order ID", "post-expirator"),
+                        "description" => __("The ID of the Cart order to refund.", "post-expirator"),
+                    ],
+                    [
+                        "name" => "refundAmount",
+                        "type" => "expression",
+                        "label" => __("Refund amount (optional)", "post-expirator"),
+                        "description" => __(
+                            "The amount to refund. Leave empty to refund the full order amount.",
+                            "post-expirator"
+                        ),
+                    ],
+                    [
+                        "name" => "restock",
+                        "type" => "select",
+                        "label" => __("Restock", "post-expirator"),
+                        "description" => __("Whether to restock the product on refund.", "post-expirator"),
+                        "settings" => [
+                            "options" => [
+                                ["value" => "NO", "label" => __("Do not restock", "post-expirator")],
+                                ["value" => "YES", "label" => __("Restock product", "post-expirator")],
+                            ],
+                        ],
+                        "default" => "NO",
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasIncomingConnection"],
+                ],
+            ],
+            "settings" => [
+                "rules" => [
+                    ["rule" => "required", "field" => "orderId"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return [
+            [
+                "name" => "input",
+                "type" => "input",
+                "label" => __("Step input", "post-expirator"),
+                "description" => __("The input data for this step.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericAction";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [["id" => "input"]],
+            "source" => [["id" => "output", "label" => __("Next", "post-expirator")]],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartRefundOrderRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Actions/Runners/NcsCartRefundOrderRunner.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartRefundOrder;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepRunnerInterface;
+
+class NcsCartRefundOrderRunner implements StepRunnerInterface
+{
+    use NcsCartResolverTrait;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        ExecutionContextInterface $executionContext,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->executionContext = $executionContext;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return NcsCartRefundOrder::getNodeTypeName();
+    }
+
+    public function setup(array $step): void
+    {
+        $this->stepProcessor->setup($step, [$this, 'setupCallback']);
+    }
+
+    public function setupCallback(array $step)
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                if (! function_exists('sc_order_refund')) {
+                    $this->logger->debugWithArgs('PublishPress Cart not active, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+
+                $nodeSettings = $this->stepProcessor->getNodeSettings(
+                    $this->stepProcessor->getNodeFromStep($step)
+                );
+
+                $orderId = $this->resolveExpressionField($nodeSettings, 'orderId');
+                if ($orderId === '' || ! ctype_digit($orderId)) {
+                    $this->logger->debugWithArgs('No valid order ID, skipping | Slug: %1$s', $nodeSlug);
+                    return;
+                }
+                $orderId = (int) $orderId;
+
+                if (get_post_type($orderId) !== 'sc_order') {
+                    $this->logger->debugWithArgs(
+                        'Post %1$s is not a Cart order, skipping | Slug: %2$s',
+                        $orderId,
+                        $nodeSlug
+                    );
+                    return;
+                }
+
+                $restock = $nodeSettings['restock'] ?? 'NO';
+                if (is_array($restock)) {
+                    $restock = $restock['value'] ?? 'NO';
+                }
+
+                // sc_order_refund() reads $data['restock'] without an isset guard, so it must always be set.
+                $data = [
+                    'id' => $orderId,
+                    'restock' => ($restock === 'YES') ? 'YES' : 'NO',
+                ];
+
+                $refundAmount = $this->resolveExpressionField($nodeSettings, 'refundAmount');
+                if ($refundAmount !== '' && is_numeric($refundAmount)) {
+                    $data['refund_amount'] = (float) $refundAmount;
+                }
+
+                $result = sc_order_refund($data);
+
+                if ($result === 'OK') {
+                    $this->logger->debugWithArgs(
+                        'Cart order %1$s refunded | Slug: %2$s',
+                        $orderId,
+                        $nodeSlug
+                    );
+                } else {
+                    $this->logger->errorWithArgs(
+                        'Cart order %1$s refund failed: %2$s | Slug: %3$s',
+                        $orderId,
+                        is_string($result) ? $result : 'unknown error',
+                        $nodeSlug
+                    );
+                }
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -30,6 +30,7 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\Dupli
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartChangeOrderStatus;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartCancelSubscription;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartDuplicateProduct;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Actions\Definitions\NcsCartRefundOrder;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnAdminInit;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnCustomAction;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnTermsAdded;
@@ -280,6 +281,7 @@ class StepTypesModel implements StepTypesModelInterface
             $nodesInstances[NcsCartChangeOrderStatus::getNodeTypeName()] = new NcsCartChangeOrderStatus();
             $nodesInstances[NcsCartCancelSubscription::getNodeTypeName()] = new NcsCartCancelSubscription();
             $nodesInstances[NcsCartDuplicateProduct::getNodeTypeName()] = new NcsCartDuplicateProduct();
+            $nodesInstances[NcsCartRefundOrder::getNodeTypeName()] = new NcsCartRefundOrder();
         }
 
         return $nodesInstances;


### PR DESCRIPTION
## Summary

Adds a **Refund Cart order** action (`action/core.ncscart-order-refund`) to Action Workflows — the refund lever deferred from the initial Cart actions PR.

Turns out refund is **free**, not Pro: Cart's `sc_order_refund()` is a global function that handles `free`/`cod`/`stripe` pay methods directly. So this ships working in free, gated on `function_exists('sc_setup_order')`.

> **Stacked on #1671** (Cart actions). Base on `feature/publishpress-cart-actions`; reuses that PR's "PublishPress Cart" category and `NcsCartResolverTrait`.

## How it works
Calls `sc_order_refund($data)` with:
- `$data['id']` — the order ID (validated as an `sc_order` post),
- `$data['refund_amount']` — optional; blank ⇒ full order amount (Cart's own default),
- `$data['restock']` — `YES`/`NO`, **always set** because `sc_order_refund()` reads it without an `isset` guard.

The function returns `'OK'` on success or an error string; the runner logs the error string on failure. Cart sets the order to `refunded` and stores it.

Fields: Order ID + Refund amount (optional) + Restock (No/Yes), all expression/select — supports `{{...}}` variables and literals.

## Notes
- Stripe refunds go through Cart's own Stripe client + `NCS_Cart_Stripe_Sync`; COD/free use the manual refund log. All handled inside `sc_order_refund()` — this action just calls it.
- Enables "auto-refund an order when a workflow condition is met" and pairs naturally with the "Cart order is refunded" trigger (#1672).

## Files
- New: 1 definition, 1 runner.
- Modified: `services.php` (case + import), `StepTypesModel.php` (registration + import).
- 4 files, all pass `php -l`.

## Test plan
- [ ] Full refund (amount blank) on a Stripe order → Stripe refund succeeds, order marked refunded.
- [ ] Partial refund with an amount.
- [ ] Restock = Yes increases product stock.
- [ ] Free/COD order refund uses the manual log path.
- [ ] Non-Cart post ID is rejected with a debug log, not a fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)