### PR TITLE
Add WooCommerce triggers (product price/stock changed, order status changed)

### DIFF
--- a/services.php
+++ b/services.php
@@ -128,6 +128,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostUp
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnPostWorkflowEnableRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnScheduleRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserRoleChangeRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooProductPriceChangedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooProductStockChangedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooOrderStatusChangedRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnTermsAddedRunner;
 use PublishPress\Future\Modules\Workflows\HooksAbstract as WorkflowsHooksAbstract;
 use PublishPress\Future\Modules\Workflows\Logger\WorkflowLogger;
@@ -1128,6 +1131,38 @@ return [
                     $stepRunner = new OnUserRoleChangeRunner(
                         $generalStepProcessor,
                         $workflowLogger
+                    );
+                    break;
+
+                case OnWooProductPriceChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnWooProductPriceChangedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
+                    );
+                    break;
+
+                case OnWooProductStockChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnWooProductStockChangedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::EXPIRABLE_POST_MODEL_FACTORY),
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
+                    );
+                    break;
+
+                case OnWooOrderStatusChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnWooOrderStatusChangedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
                     );
                     break;
 

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooOrderStatusChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooOrderStatusChanged.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnWooOrderStatusChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.woo-order-status-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onWooOrderStatusChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Order status is changed", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __("This trigger activates when a WooCommerce order's status changes.", "post-expirator");
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "orderId",
+                "type" => "integer",
+                "label" => __("Order ID", "post-expirator"),
+                "description" => __("The ID of the order.", "post-expirator"),
+            ],
+            [
+                "name" => "oldStatus",
+                "type" => "string",
+                "label" => __("Previous status", "post-expirator"),
+                "description" => __("The order's previous status.", "post-expirator"),
+            ],
+            [
+                "name" => "newStatus",
+                "type" => "string",
+                "label" => __("New status", "post-expirator"),
+                "description" => __("The order's new status.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooProductPriceChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooProductPriceChanged.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnWooProductPriceChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.woo-product-price-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onWooProductPriceChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Product price is changed", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a WooCommerce product's regular or sale price changes.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "post",
+                "type" => "post",
+                "label" => __("Product post", "post-expirator"),
+                "description" => __("The product whose price changed.", "post-expirator"),
+            ],
+            [
+                "name" => "productId",
+                "type" => "integer",
+                "label" => __("Product ID", "post-expirator"),
+                "description" => __("The ID of the product.", "post-expirator"),
+            ],
+            [
+                "name" => "price",
+                "type" => "string",
+                "label" => __("Current price", "post-expirator"),
+                "description" => __("The product's current active price.", "post-expirator"),
+            ],
+            [
+                "name" => "regularPrice",
+                "type" => "string",
+                "label" => __("Regular price", "post-expirator"),
+                "description" => __("The product's regular price.", "post-expirator"),
+            ],
+            [
+                "name" => "salePrice",
+                "type" => "string",
+                "label" => __("Sale price", "post-expirator"),
+                "description" => __("The product's sale price.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooProductStockChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooProductStockChanged.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnWooProductStockChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.woo-product-stock-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onWooProductStockChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Product stock is changed", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a WooCommerce product's stock quantity or stock status changes.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "post",
+                "type" => "post",
+                "label" => __("Product post", "post-expirator"),
+                "description" => __("The product whose stock changed.", "post-expirator"),
+            ],
+            [
+                "name" => "productId",
+                "type" => "integer",
+                "label" => __("Product ID", "post-expirator"),
+                "description" => __("The ID of the product.", "post-expirator"),
+            ],
+            [
+                "name" => "stockQuantity",
+                "type" => "string",
+                "label" => __("Stock quantity", "post-expirator"),
+                "description" => __("The product's current stock quantity.", "post-expirator"),
+            ],
+            [
+                "name" => "stockStatus",
+                "type" => "string",
+                "label" => __("Stock status", "post-expirator"),
+                "description" => __("The product's current stock status.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooOrderStatusChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooOrderStatusChangedRunner.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooOrderStatusChanged;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnWooOrderStatusChangedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnWooOrderStatusChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_WC_ORDER_STATUS_CHANGED,
+            [$this, 'onOrderStatusChangedCallback'],
+            20,
+            4
+        );
+    }
+
+    /**
+     * Fires on woocommerce_order_status_changed($order_id, $old_status, $new_status, $order).
+     *
+     * @param int $orderId
+     * @param string $oldStatus
+     * @param string $newStatus
+     * @param mixed $order
+     */
+    public function onOrderStatusChangedCallback($orderId, $oldStatus = '', $newStatus = '', $order = null): void
+    {
+        $orderId = (int) $orderId;
+        if ($orderId <= 0) {
+            return;
+        }
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'orderId' => new IntegerResolver($orderId),
+            'oldStatus' => new StringResolver((string) $oldStatus),
+            'newStatus' => new StringResolver((string) $newStatus),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $orderId);
+
+        if ($this->shouldAbortExecution($orderId, (string) $oldStatus . '>' . (string) $newStatus)) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $orderId
+        );
+    }
+
+    private function shouldAbortExecution(int $orderId, string $transition): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $orderId,
+            $transition,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and order #%d.',
+                $this->stepSlug,
+                $orderId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $orderId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for order #%d.', $this->stepSlug, $orderId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooProductPriceChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooProductPriceChangedRunner.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\PostResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooProductPriceChanged;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnWooProductPriceChangedRunner implements TriggerRunnerInterface
+{
+    private const PRICE_PROPS = ['price', 'regular_price', 'sale_price'];
+
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        \Closure $expirablePostModelFactory,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnWooProductPriceChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_WC_PRODUCT_UPDATED_PROPS,
+            [$this, 'onProductUpdatedPropsCallback'],
+            20,
+            2
+        );
+    }
+
+    /**
+     * Fires on woocommerce_product_object_updated_props($product, $updated_props).
+     *
+     * @param mixed $product
+     * @param array $updatedProps
+     */
+    public function onProductUpdatedPropsCallback($product, $updatedProps = []): void
+    {
+        if (! is_object($product) || ! method_exists($product, 'get_id')) {
+            return;
+        }
+
+        if (empty(array_intersect(self::PRICE_PROPS, (array) $updatedProps))) {
+            return;
+        }
+
+        $productId = (int) $product->get_id();
+        $post = get_post($productId);
+        if (! ($post instanceof \WP_Post)) {
+            return;
+        }
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'post' => new PostResolver($post, $this->hooks, '', $this->expirablePostModelFactory),
+            'productId' => new IntegerResolver($productId),
+            'price' => new StringResolver((string) $product->get_price()),
+            'regularPrice' => new StringResolver((string) $product->get_regular_price()),
+            'salePrice' => new StringResolver((string) $product->get_sale_price()),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $productId);
+
+        if ($this->shouldAbortExecution($productId, (string) $product->get_price())) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $productId
+        );
+    }
+
+    private function shouldAbortExecution(int $productId, string $price): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $productId,
+            $price,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and product #%d.',
+                $this->stepSlug,
+                $productId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $productId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for product #%d.', $this->stepSlug, $productId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooProductStockChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooProductStockChangedRunner.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\PostResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooProductStockChanged;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnWooProductStockChangedRunner implements TriggerRunnerInterface
+{
+    private const STOCK_PROPS = ['stock_quantity', 'stock_status', 'manage_stock'];
+
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Closure
+     */
+    private $expirablePostModelFactory;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        \Closure $expirablePostModelFactory,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->expirablePostModelFactory = $expirablePostModelFactory;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnWooProductStockChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_WC_PRODUCT_UPDATED_PROPS,
+            [$this, 'onProductUpdatedPropsCallback'],
+            20,
+            2
+        );
+    }
+
+    /**
+     * Fires on woocommerce_product_object_updated_props($product, $updated_props).
+     *
+     * @param mixed $product
+     * @param array $updatedProps
+     */
+    public function onProductUpdatedPropsCallback($product, $updatedProps = []): void
+    {
+        if (! is_object($product) || ! method_exists($product, 'get_id')) {
+            return;
+        }
+
+        if (empty(array_intersect(self::STOCK_PROPS, (array) $updatedProps))) {
+            return;
+        }
+
+        $productId = (int) $product->get_id();
+        $post = get_post($productId);
+        if (! ($post instanceof \WP_Post)) {
+            return;
+        }
+
+        $stockQuantity = $product->get_stock_quantity();
+        $stockStatus = (string) $product->get_stock_status();
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'post' => new PostResolver($post, $this->hooks, '', $this->expirablePostModelFactory),
+            'productId' => new IntegerResolver($productId),
+            'stockQuantity' => new StringResolver($stockQuantity === null ? '' : (string) $stockQuantity),
+            'stockStatus' => new StringResolver($stockStatus),
+        ]);
+
+        $this->executionContext->setVariable('global.trigger.postId', $productId);
+
+        if ($this->shouldAbortExecution($productId, (string) $stockQuantity . '|' . $stockStatus)) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $productId
+        );
+    }
+
+    private function shouldAbortExecution(int $productId, string $stockKey): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $productId,
+            $stockKey,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and product #%d.',
+                $this->stepSlug,
+                $productId
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $productId)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for product #%d.', $this->stepSlug, $productId);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/HooksAbstract.php
+++ b/src/Modules/Workflows/HooksAbstract.php
@@ -57,6 +57,16 @@ abstract class HooksAbstract
     public const ACTION_TRIGGER_FIRED = 'publishpressfuture_workflow_trigger_fired_';
 
     /**
+     * Fired by WooCommerce when a product's CRUD props change (WC_Product::save()).
+     */
+    public const ACTION_WC_PRODUCT_UPDATED_PROPS = 'woocommerce_product_object_updated_props';
+
+    /**
+     * Fired by WooCommerce when an order's status changes.
+     */
+    public const ACTION_WC_ORDER_STATUS_CHANGED = 'woocommerce_order_status_changed';
+
+    /**
      * @deprecated 4.3.2 Use ACTION_EXECUTE_STEP instead.
      */
     public const ACTION_EXECUTE_NODE = 'publishpressfuture_workflow_execute_node';

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -57,6 +57,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnPostWorkflowEnable;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnSchedule;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUserRoleChange;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooProductPriceChanged;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooProductStockChanged;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooOrderStatusChanged;
 use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
 
@@ -257,6 +260,12 @@ class StepTypesModel implements StepTypesModelInterface
             OnTermsAdded::getNodeTypeName() => new OnTermsAdded(),
             OnCustomAction::getNodeTypeName() => new OnCustomAction(),
         ];
+
+        if (class_exists('WooCommerce')) {
+            $nodesInstances[OnWooProductPriceChanged::getNodeTypeName()] = new OnWooProductPriceChanged();
+            $nodesInstances[OnWooProductStockChanged::getNodeTypeName()] = new OnWooProductStockChanged();
+            $nodesInstances[OnWooOrderStatusChanged::getNodeTypeName()] = new OnWooOrderStatusChanged();
+        }
 
         if ($this->settingsFacade->getExperimentalFeaturesStatus()) {
             $nodesInstances[OnInit::getNodeTypeName()] = new OnInit();


### PR DESCRIPTION
## Summary

Adds the WooCommerce **triggers** that correspond to the WooCommerce **actions** — so a workflow can react to store events, not just cause them. Directly answers "we have *Set Product Price*, we also need *Product Price is Changed*."

| Trigger | Mirrors action | WooCommerce hook |
|---|---|---|
| Product price is changed | Set product price | `woocommerce_product_object_updated_props` (price props) |
| Product stock is changed | Set product stock | `woocommerce_product_object_updated_props` (stock props) |
| Order status is changed | Change order status | `woocommerce_order_status_changed` |

> **Stacked on the WooCommerce stack** (#1666→#1667→#1668→#1669). Base on `feature/woocommerce-subscriptions-memberships`; reuses the "woocommerce" category + `class_exists('WooCommerce')` gating.

## How the hooks map
- `woocommerce_product_object_updated_props($product, $updated_props)` fires on `WC_Product::save()` with the list of changed CRUD props. The **price** trigger fires when `price`/`regular_price`/`sale_price` are in that list; the **stock** trigger fires on `stock_quantity`/`stock_status`/`manage_stock`. Two triggers share the hook and filter on the changed props (same pattern as the Cart order/subscription triggers).
- `woocommerce_order_status_changed($order_id, $old_status, $new_status, $order)` — the canonical WC order-status hook.

## Design
- **Product triggers** resolve the product post via `PostResolver` (products are the `product` post type) and expose `product`, `productId`, and the price/stock values.
- **Order trigger** stays **post-agnostic** (exposes `orderId` + `oldStatus` + `newStatus`, no `PostResolver`) so it's correct under **HPOS**, where orders aren't posts.
- Dedup safeguard keys include the changed value (price / stock / status transition) so distinct changes each fire rather than being deduped as one.
- Gated at registration + runtime.

## Note on verification
WooCommerce is a dependency, not vendored in this repo, so these hook names/signatures come from WooCommerce's **documented, long-stable hooks** (`woocommerce_product_object_updated_props` since WC 3.0; `woocommerce_order_status_changed` core) — not from local code. Worth a quick runtime confirmation during review.

## Files
- New: 3 trigger definitions, 3 trigger runners.
- Modified: `services.php` (3 cases + imports), `StepTypesModel.php` (gated registration + imports), `HooksAbstract.php` (2 constants).
- 9 files, all pass `php -l`.

## Test plan
- [ ] Edit a product's regular or sale price → "Product price is changed" fires with the new price.
- [ ] Change stock quantity / set out of stock → "Product stock is changed" fires.
- [ ] Move an order pending → completed → "Order status is changed" fires with old/new status (verify under HPOS too).
- [ ] Saving a product without touching price/stock does NOT fire the price/stock triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)