### PR TITLE
Add WooCommerce coupon / subscription / membership triggers

### DIFF
--- a/services.php
+++ b/services.php
@@ -131,6 +131,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnUserRo
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooProductPriceChangedRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooProductStockChangedRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooOrderStatusChangedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooCouponAppliedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooSubscriptionStatusChangedRunner;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnWooMembershipStatusChangedRunner;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners\OnTermsAddedRunner;
 use PublishPress\Future\Modules\Workflows\HooksAbstract as WorkflowsHooksAbstract;
 use PublishPress\Future\Modules\Workflows\Logger\WorkflowLogger;
@@ -1163,6 +1166,30 @@ return [
                         $workflowLogger,
                         $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
                         $executionContext
+                    );
+                    break;
+
+                case OnWooCouponAppliedRunner::getNodeTypeName():
+                    $stepRunner = new OnWooCouponAppliedRunner(
+                        $container->get(ServicesAbstract::HOOKS),
+                        $generalStepProcessor,
+                        $workflowLogger,
+                        $container->get(ServicesAbstract::WORKFLOW_EXECUTION_SAFEGUARD),
+                        $executionContext
+                    );
+                    break;
+
+                case OnWooSubscriptionStatusChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnWooSubscriptionStatusChangedRunner(
+                        $generalStepProcessor,
+                        $workflowLogger
+                    );
+                    break;
+
+                case OnWooMembershipStatusChangedRunner::getNodeTypeName():
+                    $stepRunner = new OnWooMembershipStatusChangedRunner(
+                        $generalStepProcessor,
+                        $workflowLogger
                     );
                     break;
 

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooCouponApplied.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooCouponApplied.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnWooCouponApplied implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.woo-coupon-applied";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onWooCouponApplied";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Coupon is applied", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a customer applies a WooCommerce coupon to their cart.",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "couponCode",
+                "type" => "string",
+                "label" => __("Coupon code", "post-expirator"),
+                "description" => __("The code of the applied coupon.", "post-expirator"),
+            ],
+            [
+                "name" => "couponId",
+                "type" => "integer",
+                "label" => __("Coupon ID", "post-expirator"),
+                "description" => __("The ID of the applied coupon.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return false;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooMembershipStatusChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooMembershipStatusChanged.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnWooMembershipStatusChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.woo-membership-status-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onWooMembershipStatusChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Membership status is changed", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a WooCommerce Memberships membership changes status "
+            . "(for example active, paused, expired, cancelled).",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "membershipId",
+                "type" => "integer",
+                "label" => __("Membership ID", "post-expirator"),
+                "description" => __("The ID of the user membership.", "post-expirator"),
+            ],
+            [
+                "name" => "userId",
+                "type" => "integer",
+                "label" => __("User ID", "post-expirator"),
+                "description" => __("The ID of the member.", "post-expirator"),
+            ],
+            [
+                "name" => "oldStatus",
+                "type" => "string",
+                "label" => __("Previous status", "post-expirator"),
+                "description" => __("The membership's previous status.", "post-expirator"),
+            ],
+            [
+                "name" => "newStatus",
+                "type" => "string",
+                "label" => __("New status", "post-expirator"),
+                "description" => __("The membership's new status.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return true;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooSubscriptionStatusChanged.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Definitions/OnWooSubscriptionStatusChanged.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions;
+
+use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
+use PublishPress\Future\Modules\Workflows\Models\StepTypesModel;
+
+class OnWooSubscriptionStatusChanged implements StepTypeInterface
+{
+    public static function getNodeTypeName(): string
+    {
+        return "trigger/core.woo-subscription-status-changed";
+    }
+
+    public function getElementaryType(): string
+    {
+        return StepTypesModel::STEP_TYPE_TRIGGER;
+    }
+
+    public function getReactFlowNodeType(): string
+    {
+        return "trigger";
+    }
+
+    public function getBaseSlug(): string
+    {
+        return "onWooSubscriptionStatusChanged";
+    }
+
+    public function getLabel(): string
+    {
+        return __("Subscription status is changed", "post-expirator");
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            "This trigger activates when a WooCommerce Subscriptions subscription changes status "
+            . "(for example active, on-hold, cancelled, expired).",
+            "post-expirator"
+        );
+    }
+
+    public function getIcon(): string
+    {
+        return "cart";
+    }
+
+    public function getFrecency(): int
+    {
+        return 1;
+    }
+
+    public function getVersion(): int
+    {
+        return 1;
+    }
+
+    public function getCategory(): string
+    {
+        return "woocommerce";
+    }
+
+    public function getSettingsSchema(): array
+    {
+        return [];
+    }
+
+    public function getValidationSchema(): array
+    {
+        return [
+            "connections" => [
+                "rules" => [
+                    ["rule" => "hasOutgoingConnection"],
+                ],
+            ],
+        ];
+    }
+
+    public function getStepScopedVariablesSchema(): array
+    {
+        return [
+            [
+                "name" => "subscriptionId",
+                "type" => "integer",
+                "label" => __("Subscription ID", "post-expirator"),
+                "description" => __("The ID of the subscription.", "post-expirator"),
+            ],
+            [
+                "name" => "oldStatus",
+                "type" => "string",
+                "label" => __("Previous status", "post-expirator"),
+                "description" => __("The subscription's previous status.", "post-expirator"),
+            ],
+            [
+                "name" => "newStatus",
+                "type" => "string",
+                "label" => __("New status", "post-expirator"),
+                "description" => __("The subscription's new status.", "post-expirator"),
+            ],
+        ];
+    }
+
+    public function getOutputSchema(): array
+    {
+        return $this->getStepScopedVariablesSchema();
+    }
+
+    public function getCSSClass(): string
+    {
+        return "react-flow__node-genericTrigger";
+    }
+
+    public function getHandleSchema(): array
+    {
+        return [
+            "target" => [],
+            "source" => [
+                ["id" => "output", "label" => __("Next", "post-expirator")],
+            ],
+        ];
+    }
+
+    public function isProFeature(): bool
+    {
+        return true;
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooCouponAppliedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooCouponAppliedRunner.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Core\HookableInterface;
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\IntegerResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Engine\VariableResolvers\StringResolver;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooCouponApplied;
+use PublishPress\Future\Modules\Workflows\HooksAbstract;
+use PublishPress\Future\Modules\Workflows\Interfaces\ExecutionContextInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\WorkflowExecutionSafeguardInterface;
+
+class OnWooCouponAppliedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var HookableInterface
+     */
+    private $hooks;
+
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var WorkflowExecutionSafeguardInterface
+     */
+    private $executionSafeguard;
+
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $executionContext;
+
+    /**
+     * @var array
+     */
+    private $step;
+
+    /**
+     * @var string
+     */
+    private $stepSlug;
+
+    /**
+     * @var int
+     */
+    private $workflowId;
+
+    public function __construct(
+        HookableInterface $hooks,
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger,
+        WorkflowExecutionSafeguardInterface $executionSafeguard,
+        ExecutionContextInterface $executionContext
+    ) {
+        $this->hooks = $hooks;
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+        $this->executionSafeguard = $executionSafeguard;
+        $this->executionContext = $executionContext;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnWooCouponApplied::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->step = $step;
+        $this->stepSlug = $this->stepProcessor->getSlugFromStep($this->step);
+        $this->workflowId = $workflowId;
+
+        $this->hooks->addAction(
+            HooksAbstract::ACTION_WC_APPLIED_COUPON,
+            [$this, 'onCouponAppliedCallback'],
+            20,
+            1
+        );
+    }
+
+    /**
+     * Fires on woocommerce_applied_coupon($coupon_code).
+     *
+     * @param string $couponCode
+     */
+    public function onCouponAppliedCallback($couponCode): void
+    {
+        $couponCode = (string) $couponCode;
+        if ($couponCode === '') {
+            return;
+        }
+
+        $couponId = function_exists('wc_get_coupon_id_by_code')
+            ? (int) wc_get_coupon_id_by_code($couponCode)
+            : 0;
+
+        $this->executionContext->setVariable($this->stepSlug, [
+            'couponCode' => new StringResolver($couponCode),
+            'couponId' => new IntegerResolver($couponId),
+        ]);
+
+        if ($this->shouldAbortExecution($couponCode)) {
+            return;
+        }
+
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $this->step,
+            [$this, 'processTriggerExecution'],
+            $couponCode
+        );
+    }
+
+    private function shouldAbortExecution(string $couponCode): bool
+    {
+        $uniqueId = $this->executionSafeguard->generateUniqueExecutionIdentifier([
+            $this->workflowId,
+            $this->step['node']['id'],
+            $couponCode,
+        ]);
+
+        if ($this->executionSafeguard->preventDuplicateExecution($uniqueId)) {
+            $this->logger->debugWithArgs(
+                'Duplicate execution detected for step "%s" and coupon %s.',
+                $this->stepSlug,
+                $couponCode
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function processTriggerExecution($step, $couponCode)
+    {
+        $this->stepProcessor->triggerCallbackIsRunning();
+
+        $this->logger->debugWithArgs('Trigger executed: %s for coupon %s.', $this->stepSlug, $couponCode);
+
+        $this->hooks->doAction(
+            HooksAbstract::ACTION_WORKFLOW_TRIGGER_EXECUTED,
+            $this->workflowId,
+            $this->step
+        );
+
+        $this->stepProcessor->runNextSteps($this->step);
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooMembershipStatusChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooMembershipStatusChangedRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooMembershipStatusChanged;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+
+class OnWooMembershipStatusChangedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnWooMembershipStatusChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $this->stepProcessor->setup($step, '__return_true');
+
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $this->logger->debugWithArgs('Step %1$s is a Pro feature, skipping', $nodeSlug);
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooSubscriptionStatusChangedRunner.php
+++ b/src/Modules/Workflows/Domain/Steps/Triggers/Runners/OnWooSubscriptionStatusChangedRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Runners;
+
+use PublishPress\Future\Framework\Logger\LoggerInterface;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooSubscriptionStatusChanged;
+use PublishPress\Future\Modules\Workflows\Interfaces\StepProcessorInterface;
+use PublishPress\Future\Modules\Workflows\Interfaces\TriggerRunnerInterface;
+
+class OnWooSubscriptionStatusChangedRunner implements TriggerRunnerInterface
+{
+    /**
+     * @var StepProcessorInterface
+     */
+    private $stepProcessor;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        StepProcessorInterface $stepProcessor,
+        LoggerInterface $logger
+    ) {
+        $this->stepProcessor = $stepProcessor;
+        $this->logger = $logger;
+    }
+
+    public static function getNodeTypeName(): string
+    {
+        return OnWooSubscriptionStatusChanged::getNodeTypeName();
+    }
+
+    public function setup(int $workflowId, array $step): void
+    {
+        $this->stepProcessor->executeSafelyWithErrorHandling(
+            $step,
+            function ($step) {
+                $this->stepProcessor->setup($step, '__return_true');
+
+                $nodeSlug = $this->stepProcessor->getSlugFromStep($step);
+
+                $this->logger->debugWithArgs('Step %1$s is a Pro feature, skipping', $nodeSlug);
+            }
+        );
+    }
+}

--- a/src/Modules/Workflows/HooksAbstract.php
+++ b/src/Modules/Workflows/HooksAbstract.php
@@ -67,6 +67,11 @@ abstract class HooksAbstract
     public const ACTION_WC_ORDER_STATUS_CHANGED = 'woocommerce_order_status_changed';
 
     /**
+     * Fired by WooCommerce when a coupon is applied to the cart.
+     */
+    public const ACTION_WC_APPLIED_COUPON = 'woocommerce_applied_coupon';
+
+    /**
      * @deprecated 4.3.2 Use ACTION_EXECUTE_STEP instead.
      */
     public const ACTION_EXECUTE_NODE = 'publishpressfuture_workflow_execute_node';

--- a/src/Modules/Workflows/Models/StepTypesModel.php
+++ b/src/Modules/Workflows/Models/StepTypesModel.php
@@ -60,6 +60,9 @@ use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnUs
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooProductPriceChanged;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooProductStockChanged;
 use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooOrderStatusChanged;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooCouponApplied;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooSubscriptionStatusChanged;
+use PublishPress\Future\Modules\Workflows\Domain\Steps\Triggers\Definitions\OnWooMembershipStatusChanged;
 use PublishPress\Future\Modules\Workflows\HooksAbstract;
 use PublishPress\Future\Modules\Workflows\Interfaces\StepTypeInterface;
 
@@ -265,6 +268,19 @@ class StepTypesModel implements StepTypesModelInterface
             $nodesInstances[OnWooProductPriceChanged::getNodeTypeName()] = new OnWooProductPriceChanged();
             $nodesInstances[OnWooProductStockChanged::getNodeTypeName()] = new OnWooProductStockChanged();
             $nodesInstances[OnWooOrderStatusChanged::getNodeTypeName()] = new OnWooOrderStatusChanged();
+            $nodesInstances[OnWooCouponApplied::getNodeTypeName()] = new OnWooCouponApplied();
+
+            // Subscription trigger (Pro) — only when WooCommerce Subscriptions is active.
+            if (class_exists('WC_Subscriptions')) {
+                $nodesInstances[OnWooSubscriptionStatusChanged::getNodeTypeName()] =
+                    new OnWooSubscriptionStatusChanged();
+            }
+
+            // Membership trigger (Pro) — only when WooCommerce Memberships is active.
+            if (function_exists('wc_memberships')) {
+                $nodesInstances[OnWooMembershipStatusChanged::getNodeTypeName()] =
+                    new OnWooMembershipStatusChanged();
+            }
         }
 
         if ($this->settingsFacade->getExperimentalFeaturesStatus()) {


### PR DESCRIPTION
## Summary

Fills the remaining trigger gaps so every action family has a matching trigger. Gated on WooCommerce active.

| Trigger | Free/Pro | Hook |
|---|---|---|
| Coupon is applied | **Free** | `woocommerce_applied_coupon` |
| Subscription status is changed | **Pro** (stub) | WooCommerce Subscriptions (Pro repo) |
| Membership status is changed | **Pro** (stub) | WooCommerce Memberships (Pro repo) |

> **Stacked on #1675** (WooCommerce triggers). Base on `feature/woocommerce-triggers`.

## Details
- **Coupon is applied** (working, free): hooks `woocommerce_applied_coupon($coupon_code)`, resolves the coupon ID via `wc_get_coupon_id_by_code()`, exposes `couponCode` + `couponId`. Complements the coupon actions (expire/create/generate).
- **Subscription** + **Membership** status triggers mirror the Pro subscription/membership *actions* (#1669): `isProFeature() = true` with stub runners that log "Pro feature, skipping"; the real event wiring lives in the Pro plugin. They register only when the respective extension is active (`class_exists('WC_Subscriptions')` / `function_exists('wc_memberships')`) — same gating as the Pro actions.

## Trigger ⇆ action coverage after this PR
- Product price/stock, order status → triggers ✔ (#1675) + actions ✔
- Coupon → **trigger ✔ (this PR)** + actions ✔
- Subscription / Membership → **Pro triggers ✔ (this PR)** + Pro actions ✔ (#1669)

## Files
- New: 3 trigger definitions, 3 trigger runners.
- Modified: `services.php` (3 cases + imports), `StepTypesModel.php` (gated registration + imports), `HooksAbstract.php` (coupon constant).
- 9 files, all pass `php -l`.

## Test plan
- [ ] Apply a coupon at checkout → "Coupon is applied" fires with code + ID.
- [ ] With WooCommerce Subscriptions active, the subscription trigger appears with a Pro badge and logs skip in free.
- [ ] With WooCommerce Memberships active, the membership trigger appears with a Pro badge.
- [ ] Neither Pro trigger appears when its extension is inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)