### PR TITLE
fix(expirator): match column_hook signature with Action Scheduler 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [UNRELEASED]
 
 - Fixed: Improved workflow compatibility with ACF Extended frontend forms by triggering only when the required metadata has already been processed (Issue #1649).
+- Fixed: Fatal error on Scheduled Actions screen when Action Scheduler 4.1 is loaded (Issue #1684).
 - Added: Copy workflow to text feature for development, support or debug work.
 
 [4.10.3] - 28 May, 2026

--- a/src/Modules/Expirator/Tables/ScheduledActionsTable.php
+++ b/src/Modules/Expirator/Tables/ScheduledActionsTable.php
@@ -401,14 +401,16 @@ class ScheduledActionsTable extends \ActionScheduler_ListTable
     /**
      * Renders the hook column for the scheduled actions table.
      *
-     * We're not type casting the row to an array because it's generating a conflict with
-     * ActionScheduler_ListTable::column_hook() in Action Scheduler 4.1+, which declares an untyped $row parameter.
+     * We keep the parameter untyped to match ActionScheduler_ListTable::column_hook() in
+     * Action Scheduler 4.1+, and cast to array inside the method.
      *
      * @param array $row Action array.
      * @return string
      */
     public function column_hook($row)
     {
+        $row = (array) $row;
+
         $columnHtml = '<span title="' . esc_attr($row['hook']) . '">';
 
         if ($this->rowIsAWorkflow($row)) {

--- a/src/Modules/Expirator/Tables/ScheduledActionsTable.php
+++ b/src/Modules/Expirator/Tables/ScheduledActionsTable.php
@@ -401,16 +401,15 @@ class ScheduledActionsTable extends \ActionScheduler_ListTable
     /**
      * Renders the hook column for the scheduled actions table.
      *
-     * We keep the parameter untyped to match ActionScheduler_ListTable::column_hook() in
-     * Action Scheduler 4.1+, and cast to array inside the method.
+     * The parameter is untyped to match ActionScheduler_ListTable::column_hook() in
+     * Action Scheduler 4.1+. Callers always pass the action row array built in
+     * prepare_items() (ID, hook, status_name, status, args, and related keys).
      *
      * @param array $row Action array.
      * @return string
      */
     public function column_hook($row)
     {
-        $row = (array) $row;
-
         $columnHtml = '<span title="' . esc_attr($row['hook']) . '">';
 
         if ($this->rowIsAWorkflow($row)) {

--- a/src/Modules/Expirator/Tables/ScheduledActionsTable.php
+++ b/src/Modules/Expirator/Tables/ScheduledActionsTable.php
@@ -398,7 +398,16 @@ class ScheduledActionsTable extends \ActionScheduler_ListTable
         && $row['args']['workflow'] === 'expire';
     }
 
-    public function column_hook(array $row)
+    /**
+     * Renders the hook column for the scheduled actions table.
+     *
+     * We're not type casting the row to an array because it's generating a conflict with
+     * ActionScheduler_ListTable::column_hook() in Action Scheduler 4.1+, which declares an untyped $row parameter.
+     *
+     * @param array $row Action array.
+     * @return string
+     */
+    public function column_hook($row)
     {
         $columnHtml = '<span title="' . esc_attr($row['hook']) . '">';
 


### PR DESCRIPTION
## Summary

- Remove the `array` type hint from `ScheduledActionsTable::column_hook()` so the method signature is compatible with `ActionScheduler_ListTable::column_hook($row)` introduced in Action Scheduler 4.1.
- Document that the untyped parameter is for parent signature compatibility only; callers always pass the action row array built in `prepare_items()`.
- Add an UNRELEASED changelog entry for Issue #1684.

Fixes #1684.

## Test plan

- [ ] Load the Scheduled Actions admin screen with Action Scheduler 4.1 as the loaded copy (for example via WooCommerce or another plugin bundling AS 4.1).
- [ ] Confirm the page loads without a PHP fatal error.
- [ ] Verify the hook column renders for workflow and non-workflow scheduled actions.
- [ ] Open log details for a scheduled action and confirm the hook column still renders inside the popup.


Made with [Cursor](https://cursor.com)